### PR TITLE
Add CheckReturnValue annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>guava</artifactId>
             <version>18.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.1</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/main/java/com/shapesecurity/functional/F.java
+++ b/src/main/java/com/shapesecurity/functional/F.java
@@ -18,6 +18,9 @@ package com.shapesecurity.functional;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 @FunctionalInterface
 public interface F<A, R> {
     @NotNull

--- a/src/main/java/com/shapesecurity/functional/F2.java
+++ b/src/main/java/com/shapesecurity/functional/F2.java
@@ -18,6 +18,9 @@ package com.shapesecurity.functional;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 @FunctionalInterface
 public interface F2<A, B, R> {
     @NotNull

--- a/src/main/java/com/shapesecurity/functional/F3.java
+++ b/src/main/java/com/shapesecurity/functional/F3.java
@@ -18,6 +18,9 @@ package com.shapesecurity.functional;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 @FunctionalInterface
 public interface F3<A, B, C, R> {
     @NotNull

--- a/src/main/java/com/shapesecurity/functional/F4.java
+++ b/src/main/java/com/shapesecurity/functional/F4.java
@@ -18,6 +18,9 @@ package com.shapesecurity.functional;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 @FunctionalInterface
 public interface F4<A, B, C, D, R> {
     @NotNull

--- a/src/main/java/com/shapesecurity/functional/Pair.java
+++ b/src/main/java/com/shapesecurity/functional/Pair.java
@@ -20,6 +20,9 @@ import com.shapesecurity.functional.data.HashCodeBuilder;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 public final class Pair<A, B> {
     public final A left;
     public final B right;

--- a/src/main/java/com/shapesecurity/functional/Tuple3.java
+++ b/src/main/java/com/shapesecurity/functional/Tuple3.java
@@ -20,6 +20,9 @@ import com.shapesecurity.functional.data.HashCodeBuilder;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 public final class Tuple3<A, B, C> {
     @NotNull
     public final A a;

--- a/src/main/java/com/shapesecurity/functional/Tuple4.java
+++ b/src/main/java/com/shapesecurity/functional/Tuple4.java
@@ -20,6 +20,9 @@ import com.shapesecurity.functional.data.HashCodeBuilder;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 public final class Tuple4<A, B, C, D> {
     @NotNull
     public final A a;

--- a/src/main/java/com/shapesecurity/functional/data/ConcatList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ConcatList.java
@@ -35,6 +35,9 @@ import com.shapesecurity.functional.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 public abstract class ConcatList<T> implements Iterable<T> {
     @SuppressWarnings("StaticInitializerReferencesSubClass")
     private static final Empty<Object> EMPTY = new Empty<>();

--- a/src/main/java/com/shapesecurity/functional/data/Either.java
+++ b/src/main/java/com/shapesecurity/functional/data/Either.java
@@ -21,6 +21,9 @@ import com.shapesecurity.functional.F;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 public final class Either<A, B> {
     private final Object data;
 

--- a/src/main/java/com/shapesecurity/functional/data/HashCodeBuilder.java
+++ b/src/main/java/com/shapesecurity/functional/data/HashCodeBuilder.java
@@ -18,9 +18,12 @@ package com.shapesecurity.functional.data;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * HasCodeBuilder is a simple FNV hash builder for hash code generation of
  */
+@CheckReturnValue
 public final class HashCodeBuilder {
     //int is a 32 bit integer
     private static final int INITIAL_VALUE = -2128831035;

--- a/src/main/java/com/shapesecurity/functional/data/HashTable.java
+++ b/src/main/java/com/shapesecurity/functional/data/HashTable.java
@@ -27,12 +27,15 @@ import com.shapesecurity.functional.Unit;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * An immutable hash trie tree implementation.
  *
  * @param <K> Key type
  * @param <V> Value type
  */
+@CheckReturnValue
 public abstract class HashTable<K, V> {
     private final static Hasher<Object> EQUALITY_HASHER = new Hasher<Object>() {
         @Override

--- a/src/main/java/com/shapesecurity/functional/data/Hasher.java
+++ b/src/main/java/com/shapesecurity/functional/data/Hasher.java
@@ -18,6 +18,9 @@ package com.shapesecurity.functional.data;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 public interface Hasher<A> {
     int hash(@NotNull A data);
 

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
@@ -32,6 +32,8 @@ import com.shapesecurity.functional.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * An immutable singly linked list implementation. None of the operations in {@link ImmutableList}
  * changes the list itself. Therefore you can freely share the list in your system. <p> This is a
@@ -44,6 +46,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <A> The super type of all the elements.
  */
+@CheckReturnValue
 public abstract class ImmutableList<A> implements Iterable<A> {
     @SuppressWarnings("StaticInitializerReferencesSubClass")
     private static final ImmutableList<Object> EMPTY = new Nil<>();

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -5,6 +5,9 @@ import com.shapesecurity.functional.Unit;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 public class ImmutableSet<T> {
     @NotNull
     private final HashTable<T, Unit> data;

--- a/src/main/java/com/shapesecurity/functional/data/Maybe.java
+++ b/src/main/java/com/shapesecurity/functional/data/Maybe.java
@@ -28,6 +28,9 @@ import com.shapesecurity.functional.Thunk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 public final class Maybe<A> {
     private final static int NOTHING_HASH_CODE = HashCodeBuilder.put(HashCodeBuilder.init(), "Nothing");
 

--- a/src/main/java/com/shapesecurity/functional/data/Monoid.java
+++ b/src/main/java/com/shapesecurity/functional/data/Monoid.java
@@ -20,6 +20,9 @@ import com.shapesecurity.functional.Unit;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 public interface Monoid<T> extends Semigroup<T> {
     public static final UnitIdentity UNIT = new UnitIdentity();
     public static final IntegerAdditive INTEGER_ADDITIVE = new IntegerAdditive();

--- a/src/main/java/com/shapesecurity/functional/data/MultiHashTable.java
+++ b/src/main/java/com/shapesecurity/functional/data/MultiHashTable.java
@@ -7,8 +7,11 @@ import com.shapesecurity.functional.Pair;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
 // Map from keys to multiple values.
 // This class does not distinguish between "key is present, but associated with empty list" and "key is not present". If you need that, don't use this class.
+@CheckReturnValue
 public class MultiHashTable<K, V> { // TODO should be elsewhere... and better
     @NotNull
     private final HashTable<K, ImmutableList<V>> data;

--- a/src/main/java/com/shapesecurity/functional/data/Semigroup.java
+++ b/src/main/java/com/shapesecurity/functional/data/Semigroup.java
@@ -20,6 +20,9 @@ import com.shapesecurity.functional.Unit;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
+
+@CheckReturnValue
 public interface Semigroup<T> {
     UnitIdentity UNIT_IDENTITY = new UnitIdentity();
     IntegerAdditive INTEGER_ADDITIVE = new IntegerAdditive();


### PR DESCRIPTION
This annotation gives a compiler warning when an annotated method or a method of an annotated class (including both static and instance methods and methods in nested classes and subclasses) is used a position which does not make use of the return value of that method.

For example, `someImmutableSet.add(0);` will now give a compiler warning.