### PR TITLE
Add length check to NonEmptyImmutableList.equals. Fixes #49

### DIFF
--- a/src/main/java/com/shapesecurity/functional/data/NonEmptyImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/NonEmptyImmutableList.java
@@ -63,6 +63,11 @@ public final class NonEmptyImmutableList<T> extends ImmutableList<T> {
         // Manually expanded tail recursion
         ImmutableList<T> l = this;
         ImmutableList<T> r = (ImmutableList<T>) o;
+
+        if (l.length != r.length) {
+            return false;
+        }
+        
         while (l instanceof NonEmptyImmutableList && r instanceof NonEmptyImmutableList) {
             if (l == r) {
                 return true;


### PR DESCRIPTION
Provides improved performance in the general case that two non-equal lists have differing lengths by avoiding iteration.