### PR TITLE
Add ImmutableDoubleList, which is backed by a mutable Java LinkedList, #42

### DIFF
--- a/src/main/java/com/shapesecurity/functional/data/IImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/IImmutableList.java
@@ -1,0 +1,92 @@
+package com.shapesecurity.functional.data;
+
+import com.shapesecurity.functional.F;
+import com.shapesecurity.functional.F2;
+import com.shapesecurity.functional.Pair;
+
+import javax.annotation.Nonnull;
+
+public interface IImmutableList<T> extends Iterable<T> {
+
+    default boolean isEmpty() {
+        return true;
+    }
+
+    default boolean isNotEmpty() {
+        return false;
+    }
+
+    int length();
+
+    @Nonnull
+    INonEmptyImmutableList<T> cons(T left);
+
+    @Nonnull
+    <B> B foldLeft(@Nonnull F2<B, ? super T, B> f, @Nonnull B init);
+
+    @Nonnull
+    <B> B foldRight(@Nonnull F2<? super T, B, B> f, @Nonnull B init);
+
+    @Nonnull
+    IImmutableList<T> filter(@Nonnull F<T, Boolean> f);
+
+    int count(@Nonnull F<T, Boolean> f);
+
+    @Nonnull
+    <B> IImmutableList<B> map(@Nonnull F<T, B> f);
+
+    @Nonnull
+    <B> IImmutableList<B> mapWithIndex(@Nonnull F2<Integer, T, B> f);
+
+    @Nonnull
+    <B> IImmutableList<B> chain(@Nonnull F<T, IImmutableList<B>> f);
+
+    boolean exists(@Nonnull F<T, Boolean> f);
+
+    boolean contains(@Nonnull T t);
+
+    @Nonnull
+    IImmutableList<T> removeAll(@Nonnull F<T, Boolean> f);
+
+    @Nonnull
+    IImmutableList<T> reverse();
+
+    @Nonnull
+    Maybe<T> index(int index);
+
+    @Nonnull
+    Maybe<Integer> findIndexEquality(@Nonnull T t);
+
+    @Nonnull
+    Maybe<Integer> findIndexIdentity(@Nonnull T t);
+
+    @Nonnull
+    Maybe<T> find(@Nonnull F<T, Boolean> f);
+
+    @Nonnull
+    Maybe<Integer> findIndex(@Nonnull F<T, Boolean> f);
+
+    @Nonnull
+    <B> Maybe<B> findMap(@Nonnull F<T, Maybe<B>> f);
+
+    @Nonnull
+    <B extends T> IImmutableList<T> append(@Nonnull IImmutableList<B> defaultClause);
+
+    @Nonnull
+    <B extends T> IImmutableList<T> patch(int index, int patchLength, @Nonnull IImmutableList<B> replacements);
+
+    @Nonnull
+    ImmutableSet<T> uniqByEquality();
+
+    @Nonnull
+    ImmutableSet<T> uniqByIdentity();
+
+    @Nonnull
+    <B> ImmutableSet<T> uniqByEqualityOn(@Nonnull F<T, B> f);
+
+    @Override
+    boolean equals(Object o);
+
+    @Override
+    int hashCode();
+}

--- a/src/main/java/com/shapesecurity/functional/data/INonEmptyImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/INonEmptyImmutableList.java
@@ -1,0 +1,74 @@
+package com.shapesecurity.functional.data;
+
+import com.shapesecurity.functional.F;
+import com.shapesecurity.functional.F2;
+import com.shapesecurity.functional.Pair;
+
+import javax.annotation.Nonnull;
+
+public interface INonEmptyImmutableList<T> extends IImmutableList<T> {
+
+    @Nonnull
+    INonEmptyImmutableList<T> append(T right);
+
+    @Nonnull
+    INonEmptyImmutableList<T> prepend(T left);
+
+    @Nonnull
+    T head();
+
+    @Nonnull
+    T last();
+
+    @Nonnull
+    IImmutableList<T> tail();
+
+    @Nonnull
+    IImmutableList<T> init();
+
+    @Nonnull
+    IImmutableList<T> take(int n);
+
+    @Nonnull
+    IImmutableList<T> drop(int n);
+
+    @Nonnull
+    Maybe<NonEmptyImmutableList<T>> toNonEmptyList();
+
+    @Nonnull
+    <B, C> INonEmptyImmutableList<C> zipWith(@Nonnull F2<T, B, C> f, @Nonnull INonEmptyImmutableList<B> list);
+
+    @Override
+    default boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    default boolean isNotEmpty() {
+        return true;
+    }
+
+    @Override
+    @Nonnull
+    <B> INonEmptyImmutableList<B> map(@Nonnull F<T, B> f);
+
+    @Override
+    @Nonnull
+    <B> INonEmptyImmutableList<B> mapWithIndex(@Nonnull F2<Integer, T, B> f);
+
+    @Override
+    @Nonnull
+    <B> IImmutableList<B> chain(@Nonnull F<T, IImmutableList<B>> f);
+
+    @Override
+    @Nonnull
+    INonEmptyImmutableList<T> reverse();
+
+    @Override
+    @Nonnull
+    <B extends T> INonEmptyImmutableList<T> append(@Nonnull IImmutableList<B> defaultClause);
+
+    @Nonnull
+    T[] toArray(@Nonnull T[] target);
+
+}

--- a/src/main/java/com/shapesecurity/functional/data/INonEmptyImmutableListExt.java
+++ b/src/main/java/com/shapesecurity/functional/data/INonEmptyImmutableListExt.java
@@ -1,0 +1,19 @@
+package com.shapesecurity.functional.data;
+
+import com.shapesecurity.functional.F;
+import com.shapesecurity.functional.F2;
+import com.shapesecurity.functional.Pair;
+
+import javax.annotation.Nonnull;
+
+public interface INonEmptyImmutableListExt<T> extends INonEmptyImmutableList<T> {
+
+    @Nonnull
+    Pair<IImmutableList<T>, IImmutableList<T>> span(@Nonnull F<T, Boolean> f);
+
+    @Nonnull
+    <B, C> Pair<B, INonEmptyImmutableList<C>> mapAccumL(@Nonnull F2<B, T, Pair<B, C>> f, @Nonnull B acc);
+
+    @Nonnull
+    <B> Maybe<B> decons(@Nonnull F2<T, IImmutableList<T>, B> f);
+}

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableDoubleList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableDoubleList.java
@@ -1,0 +1,482 @@
+package com.shapesecurity.functional.data;
+
+import com.shapesecurity.functional.F;
+import com.shapesecurity.functional.F2;
+import com.shapesecurity.functional.Pair;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class ImmutableDoubleList<T> implements INonEmptyImmutableListExt<T> {
+    @Nonnull
+    private final LinkedList<T> list;
+    // It would be a nice optimization to use our own mutable linked list impl with restartable iterators.
+    private final List<T> subList;
+    private final int start;
+    private final int end;
+    private final int hashCode;
+    public final int length;
+
+    protected ImmutableDoubleList(@Nonnull LinkedList<T> list, int start, int end) {
+        this.length = end - start;
+        this.list = list;
+        if (this.list.size() < end || start >= end || start < 0) {
+            throw new IllegalArgumentException("invalid range");
+        }
+        this.subList = start == 0 && end == list.size() ? list : list.subList(start, end);
+        this.start = start;
+        this.end = end;
+        this.hashCode = this.calcHashCode();
+    }
+
+    private List<T> subList(int start, int end) {
+        return list.subList(this.start + start, this.end - (length - end));
+    }
+
+    @Nonnull
+    public IImmutableList<T> slice(int start, int end) {
+        return ImmutableList.fromLinkedList(list, this.start + start, this.end - (length - end));
+    }
+
+    @Nonnull
+    @Override
+    public ImmutableDoubleList<T> cons(T left) {
+        return this.prepend(left);
+    }
+
+    @Nonnull
+    @Override
+    public ImmutableDoubleList<T> append(T right) {
+        LinkedList<T> list = new LinkedList<>(subList);
+        list.addLast(right);
+        return (ImmutableDoubleList<T>) ImmutableList.fromLinkedList(list);
+    }
+
+    @Nonnull
+    @Override
+    public ImmutableDoubleList<T> prepend(T left) {
+        LinkedList<T> list = new LinkedList<>(subList);
+        list.addFirst(left);
+        return (ImmutableDoubleList<T>) ImmutableList.fromLinkedList(list);
+    }
+
+    private int calcHashCode() {
+        return subList.hashCode();
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    @Nonnull
+    @Override
+    public <B> B foldLeft(@Nonnull F2<B, ? super T, B> f, @Nonnull B init) {
+        for (T entry : subList) {
+            init = f.apply(init, entry);
+        }
+        return init;
+    }
+
+    @Nonnull
+    @Override
+    public <B> B foldRight(@Nonnull F2<? super T, B, B> f, @Nonnull B init) {
+        Iterator<T> it = this.reverseIterator();
+        int i = 0;
+        for (; i < length && it.hasNext(); i++) {
+            init = f.apply(it.next(), init);
+        }
+        if (i < length) {
+            throw new RuntimeException("Unexpected short underlying linked list");
+        }
+        return init;
+    }
+
+    @Nonnull
+    @Override
+    public T head() {
+        return subList.get(0);
+    }
+
+    @Nonnull
+    @Override
+    public T last() {
+        return subList.get(subList.size() - 1);
+    }
+
+    @Nonnull
+    @Override
+    public IImmutableList<T> tail() {
+        if (this.length == 1) {
+            return ImmutableList.empty();
+        }
+        return this.slice(1, this.length);
+    }
+
+    @Nonnull
+    @Override
+    public IImmutableList<T> init() {
+        if (this.length == 1) {
+            return ImmutableList.empty();
+        }
+        return this.slice(0, this.length - 1);
+    }
+
+    @Nonnull
+    @Override
+    public IImmutableList<T> filter(@Nonnull F<T, Boolean> f) {
+        LinkedList<T> newList = new LinkedList<>();
+        for (T entry : subList) {
+            if (f.apply(entry)) {
+                newList.addLast(entry);
+            }
+        }
+        return ImmutableList.fromLinkedList(newList, 0, newList.size());
+    }
+
+    @Override
+    public int count(@Nonnull F<T, Boolean> f) {
+        int count = 0;
+        for (T entry : subList) {
+            if (f.apply(entry)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    @Nonnull
+    @Override
+    public <B> INonEmptyImmutableList<B> map(@Nonnull F<T, B> f) {
+        LinkedList<B> newList = new LinkedList<>();
+        for (T entry : subList) {
+            newList.addLast(f.apply(entry));
+        }
+        return (INonEmptyImmutableList<B>)ImmutableList.fromLinkedList(newList, 0, newList.size());
+    }
+
+    @Nonnull
+    @Override
+    public <B> INonEmptyImmutableList<B> mapWithIndex(@Nonnull F2<Integer, T, B> f) {
+        LinkedList<B> newList = new LinkedList<>();
+        int i = 0;
+        for (T entry : subList) {
+            newList.addLast(f.apply(i, entry));
+            i++;
+        }
+        return (INonEmptyImmutableList<B>)ImmutableList.fromLinkedList(newList, 0, newList.size());
+    }
+
+    @Nonnull
+    @Override
+    public IImmutableList<T> take(int n) {
+        return this.slice(0, n >= length ? length : n);
+    }
+
+    @Nonnull
+    @Override
+    public IImmutableList<T> drop(int n) {
+        return n >= length ? ImmutableList.empty() : this.slice(n, length);
+    }
+
+    @Nonnull
+    @Override
+    public Maybe<NonEmptyImmutableList<T>> toNonEmptyList() {
+        return Maybe.of((NonEmptyImmutableList<T>) ImmutableList.from(subList));
+    }
+
+    @Override
+    public int length() {
+        return length;
+    }
+
+    @Override
+    @Nonnull
+    public <B> Maybe<B> decons(@Nonnull F2<T, IImmutableList<T>, B> f) {
+        return Maybe.of(f.apply(subList.get(0), this.tail())); // would be much faster if it took an Iterable
+    }
+
+    @Nonnull
+    @Override
+    public <B, C> INonEmptyImmutableList<C> zipWith(@Nonnull F2<T, B, C> f, @Nonnull INonEmptyImmutableList<B> list) {
+        Iterator<B> otherIterator = list.iterator();
+        Iterator<T> ourIterator = subList.iterator();
+        LinkedList<C> output = new LinkedList<>();
+        while (ourIterator.hasNext() && otherIterator.hasNext()) {
+            output.addLast(f.apply(ourIterator.next(), otherIterator.next()));
+        }
+        return (INonEmptyImmutableList<C>) ImmutableList.fromLinkedList(output, 0, output.size());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <B> List<B> listFromImmutableList(IImmutableList<B> list) {
+        if (list instanceof ImmutableDoubleList) {
+            return ((ImmutableDoubleList<B>) list).subList;
+        } else {
+            return Arrays.asList((B[]) ((ImmutableList<Object>) list).toArray(new Object[0]));
+        }
+    }
+
+    @Nonnull
+    @Override
+    @SuppressWarnings("unchecked")
+    public <B extends T> INonEmptyImmutableList<T> append(@Nonnull IImmutableList<B> defaultClause) {
+         if (defaultClause.isEmpty()) {
+            return this;
+        }
+        if (defaultClause instanceof ImmutableDoubleList) {
+            LinkedList<T> newList = new LinkedList<>(this.subList);
+            newList.addAll(((ImmutableDoubleList<B>) defaultClause).subList);
+            return (INonEmptyImmutableList<T>) ImmutableList.fromLinkedList(newList, 0, newList.size());
+        } else if (defaultClause instanceof NonEmptyImmutableList && ((NonEmptyImmutableList<T>)defaultClause).length <= this.length) {
+            LinkedList<T> newList = new LinkedList<>(this.subList);
+            newList.addAll(listFromImmutableList(defaultClause));
+            return (INonEmptyImmutableList<T>) ImmutableList.fromLinkedList(newList, 0, newList.size());
+        } else {
+            // contingency
+            return this.toNonEmptyList().fromJust().append(defaultClause);
+        }
+    }
+
+    @Override
+    public boolean exists(@Nonnull F<T, Boolean> f) {
+        for (T entry : subList) {
+            if (f.apply(entry)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean contains(@Nonnull T t) {
+        for (T entry : subList) {
+            if (entry == t) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    @Nonnull
+    public Pair<IImmutableList<T>, IImmutableList<T>> span(@Nonnull F<T, Boolean> f) {
+        int splitIndex = 0;
+        for (T entry : subList) {
+            if (!f.apply(entry)) {
+                break;
+            }
+            splitIndex++;
+        }
+        return new Pair<>(this.slice(0, splitIndex), this.slice(splitIndex, length));
+    }
+
+    @Nonnull
+    @Override
+    public <B> IImmutableList<B> chain(@Nonnull F<T, IImmutableList<B>> f) {
+        LinkedList<B> newList = new LinkedList<>();
+        for (T entry : subList) {
+            newList.addAll(listFromImmutableList(f.apply(entry)));
+        }
+        return ImmutableList.fromLinkedList(newList, 0, newList.size());
+    }
+
+    @Nonnull
+    @Override
+    public IImmutableList<T> removeAll(@Nonnull F<T, Boolean> f) {
+        LinkedList<T> newList = new LinkedList<>();
+        for (T entry : subList) {
+            if (!f.apply(entry)) {
+                newList.addLast(entry);
+            }
+        }
+        return ImmutableList.fromLinkedList(newList, 0, newList.size());
+    }
+
+    @Nonnull
+    @Override
+    public INonEmptyImmutableList<T> reverse() {
+        return (INonEmptyImmutableList<T>) ImmutableList.fromLinkedList(StreamSupport.stream(this.reverseIterable().spliterator(), false).collect(Collectors.toCollection(LinkedList::new)), 0, this.length);
+    }
+
+    @Override
+    @Nonnull
+    public <B, C> Pair<B, INonEmptyImmutableList<C>> mapAccumL(@Nonnull F2<B, T, Pair<B, C>> f, @Nonnull B acc) {
+        LinkedList<C> newList = new LinkedList<>();
+        for (T entry : subList) {
+            Pair<B, C> result = f.apply(acc, entry);
+            acc = result.left;
+            newList.addLast(result.right);
+        }
+        return new Pair<>(acc, (INonEmptyImmutableList<C>) ImmutableList.fromLinkedList(newList, 0, newList.size()));
+    }
+
+    @Nonnull
+    @Override
+    public ImmutableSet<T> uniqByEquality() {
+        return ImmutableSet.<T>emptyUsingEquality().putAll(this);
+    }
+
+    @Nonnull
+    @Override
+    public ImmutableSet<T> uniqByIdentity() {
+        return ImmutableSet.<T>emptyUsingIdentity().putAll(this);
+    }
+
+    @Nonnull
+    @Override
+    public <B> ImmutableSet<T> uniqByEqualityOn(@Nonnull F<T, B> f) {
+        ImmutableSet<B> set = ImmutableSet.emptyUsingEquality();
+        ImmutableSet<T> out = ImmutableSet.emptyUsingIdentity();
+        for (T entry : subList) {
+            B result = f.apply(entry);
+            if (!set.contains(result)) {
+                out = out.put(entry);
+                set = set.put(result);
+            }
+        }
+        return out;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof ImmutableDoubleList) {
+            if (((ImmutableDoubleList) o).length != length) {
+                return false;
+            }
+            return ((ImmutableDoubleList) o).subList.equals(subList);
+        } else if (o instanceof ImmutableList) {
+            if (((ImmutableList) o).length != length) {
+                return false;
+            }
+            Iterator otherIterator = ((ImmutableList) o).iterator();
+            Iterator ourIterator = subList.iterator();
+            while (ourIterator.hasNext()) {
+                if (!otherIterator.next().equals(ourIterator)) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return subList.iterator();
+    }
+
+    public Iterator<T> reverseIterator() {
+        if (subList == list) {
+            return list.descendingIterator();
+        } else {
+            Iterator<T> it = list.descendingIterator();
+            for (int i = this.list.size(); i > end; i--) {
+                it.next();
+            }
+            return it;
+        }
+    }
+
+    public Iterable<T> reverseIterable() {
+        return this::reverseIterator;
+    }
+
+    @Override
+    @Nonnull
+    public T[] toArray(@Nonnull T[] target) {
+        return subList.toArray(target);
+    }
+
+    @Override
+    public void forEach(@Nonnull Consumer<? super T> action) {
+        for (T entry : subList) {
+            action.accept(entry);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public <B extends T> IImmutableList<T> patch(int index, int patchLength, @Nonnull IImmutableList<B> replacements) {
+        LinkedList<T> newList = new LinkedList<>(this.subList(0, index));
+        newList.addAll(listFromImmutableList(replacements));
+        newList.addAll(this.subList(index + patchLength, length));
+        return ImmutableList.fromLinkedList(newList);
+    }
+
+    @Nonnull
+    @Override
+    public Maybe<T> index(int index) {
+        return index < 0 || index > length ? Maybe.empty() : Maybe.of(subList.get(index));
+    }
+
+    @Override
+    @Nonnull
+    public Maybe<Integer> findIndexEquality(@Nonnull T t) {
+        int i = 0;
+        for (T entry : subList) {
+            if (entry.equals(t)) {
+                return Maybe.of(i);
+            }
+            i++;
+        }
+        return Maybe.empty();
+    }
+
+    @Override
+    @Nonnull
+    public Maybe<Integer> findIndexIdentity(@Nonnull T t) {
+        int i = 0;
+        for (T entry : subList) {
+            if (entry == t) {
+                return Maybe.of(i);
+            }
+            i++;
+        }
+        return Maybe.empty();
+    }
+
+    @Nonnull
+    @Override
+    public Maybe<T> find(@Nonnull F<T, Boolean> f) {
+        for (T entry : subList) {
+            if (f.apply(entry)) {
+                return Maybe.of(entry);
+            }
+        }
+        return Maybe.empty();
+    }
+
+    @Nonnull
+    @Override
+    public Maybe<Integer> findIndex(@Nonnull F<T, Boolean> f) {
+        int i = 0;
+        for (T entry : subList) {
+            if (f.apply(entry)) {
+                return Maybe.of(i);
+            }
+            i++;
+        }
+        return Maybe.empty();
+    }
+
+    @Nonnull
+    @Override
+    public <B> Maybe<B> findMap(@Nonnull F<T, Maybe<B>> f) {
+        for (T entry : subList) {
+            Maybe<B> result = f.apply(entry);
+            if (result.isJust()) {
+                return result;
+            }
+        }
+        return Maybe.empty();
+    }
+
+}

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -87,7 +87,7 @@ public class ImmutableSet<T> implements Iterable<T> {
     }
 
     @Nonnull
-    public <B extends T> ImmutableSet<T> putAll(@Nonnull ImmutableList<B> list) {
+    public <B extends T> ImmutableSet<T> putAll(@Nonnull IImmutableList<B> list) {
         return list.foldLeft(ImmutableSet::put, this);
     }
 

--- a/src/main/java/com/shapesecurity/functional/data/Nil.java
+++ b/src/main/java/com/shapesecurity/functional/data/Nil.java
@@ -35,6 +35,11 @@ public final class Nil<T> extends ImmutableList<T> {
     }
 
     @Override
+    public int length() {
+        return this.length;
+    }
+
+    @Override
     protected int calcHashCode() {
         return DEFAULT_HASH_CODE;
     }
@@ -142,6 +147,14 @@ public final class Nil<T> extends ImmutableList<T> {
         return (ImmutableList<T>) defaultClause;
     }
 
+    @Nonnull
+    @Override
+    @SuppressWarnings("unchecked")
+    public <B extends T> IImmutableList<T> append(@Nonnull IImmutableList<B> defaultClause) {
+        // This is safe due to erasure.
+        return (IImmutableList<T>) defaultClause;
+    }
+
     @Override
     public boolean exists(@Nonnull F<T, Boolean> f) {
         return false;
@@ -167,6 +180,13 @@ public final class Nil<T> extends ImmutableList<T> {
     @Override
     @SuppressWarnings("unchecked")
     public <B> ImmutableList<B> flatMap(@Nonnull F<T, ImmutableList<B>> f) {
+        return (ImmutableList<B>) this;
+    }
+
+    @Nonnull
+    @Override
+    @SuppressWarnings("unchecked")
+    public <B> IImmutableList<B> chain(@Nonnull F<T, IImmutableList<B>> f) {
         return (ImmutableList<B>) this;
     }
 

--- a/src/test/java/com/shapesecurity/functional/TestBase.java
+++ b/src/test/java/com/shapesecurity/functional/TestBase.java
@@ -16,6 +16,7 @@
 
 package com.shapesecurity.functional;
 
+import com.shapesecurity.functional.data.ImmutableDoubleList;
 import com.shapesecurity.functional.data.ImmutableList;
 import com.shapesecurity.functional.data.NonEmptyImmutableList;
 
@@ -29,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.LinkedList;
 import java.util.Random;
 
 public abstract class TestBase {
@@ -69,11 +71,17 @@ public abstract class TestBase {
     // static
 
     static protected NonEmptyImmutableList<Integer> LONG_LIST = ImmutableList.of(rand());
+    static protected ImmutableDoubleList<Integer> LONG_DOUBLE_LIST = ImmutableList.ofDouble(rand());
     static protected NonEmptyImmutableList<Integer> LONG_INT_LIST = ImmutableList.of(0);
     static {
         for (int i = 0; i < 1000; i++) {
             LONG_LIST = LONG_LIST.cons(rand());
         }
+        LinkedList<Integer> list = new LinkedList<>();
+        for (int i = 0; i < 1000; i++) {
+            list.add(rand());
+        }
+        LONG_DOUBLE_LIST = (ImmutableDoubleList<Integer>)LONG_DOUBLE_LIST.append(ImmutableList.fromLinkedList(list));
         for (int i = 0; i < 1 << 14; i++) {
             LONG_INT_LIST = LONG_INT_LIST.cons(i);
         }

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableDoubleListTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableDoubleListTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2014 Shape Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.shapesecurity.functional.data;
+
+import com.shapesecurity.functional.Effect;
+import com.shapesecurity.functional.Pair;
+import com.shapesecurity.functional.TestBase;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import static org.junit.Assert.*;
+
+public class ImmutableDoubleListTest extends TestBase {
+
+    private void testWithSpecialLists(@Nonnull Effect<ImmutableDoubleList<Integer>> f) {
+        f.apply(ImmutableList.ofDouble(0));
+        f.apply(ImmutableList.ofDouble(0, 1, 2));
+        f.apply(ImmutableList.ofDouble(3, 2, 1));
+        f.apply(LONG_DOUBLE_LIST);
+    }
+
+    @Test
+    public void testList() {
+        int a = rand();
+        ImmutableDoubleList<Integer> list = (ImmutableDoubleList<Integer>)ImmutableList.fromLinkedList(new LinkedList<>(Arrays.asList(a)));
+        assertEquals(list.length, 1);
+        assertEquals(list.head().intValue(), a);
+        assertEquals(list.tail(), ImmutableList.<Integer>empty());
+    }
+
+    @Test
+    public void testEquals() {
+        testWithSpecialLists(this::testEquals);
+    }
+
+    public void testEquals(ImmutableDoubleList<Integer> list) {
+        assertEquals(list, list);
+        assertNotEquals(list, ImmutableList.empty());
+    }
+
+    @Test
+    public void testReverse() {
+        assertEquals(ImmutableList.empty().reverse(), ImmutableList.empty());
+        assertEquals(ImmutableList.ofDouble(1).reverse(), ImmutableList.ofDouble(1));
+        assertEquals(ImmutableList.ofDouble(1, 2, 3).reverse(), ImmutableList.ofDouble(3, 2, 1));
+    }
+
+    @Test
+    public void testLast() {
+        testWithSpecialLists(this::testLast);
+    }
+
+    private void testLast(ImmutableDoubleList<Integer> list) {
+        assertEquals(list.last(), list.index(list.length - 1).fromJust());
+    }
+
+    @Test
+    public void testInit() {
+        testWithSpecialLists(this::testInit);
+    }
+
+    private void testInit(ImmutableDoubleList<Integer> list) {
+        assertEquals(list.init(), list.take(list.length - 1));
+    }
+
+    @Test
+    public void testExists() {
+        ImmutableDoubleList<Integer> list = ImmutableList.ofDouble(1, 2, 3);
+        assertTrue(list.exists(x -> x == 2));
+        assertFalse(list.exists(x -> x == 4));
+    }
+
+    @Test
+    public void testContains() {
+        ImmutableDoubleList<Integer> list = ImmutableList.ofDouble(1, 2, 3);
+        ImmutableDoubleList<IImmutableList<Integer>> listOfLists = ImmutableList.ofDouble(list);
+        assertTrue(listOfLists.contains(list));
+        assertFalse(listOfLists.contains(ImmutableList.ofDouble(1, 2, 3)));
+        assertFalse(listOfLists.contains(ImmutableList.emptyI()));
+    }
+
+    @Test
+    public void testMap() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        assertEquals(list, list.map(str -> str));
+        ImmutableDoubleList<String> listExpected = ImmutableList.ofDouble("str1x", "str2x", "str3x");
+        assertEquals(listExpected, list.map(str -> str + "x"));
+        ImmutableDoubleList<String> pre = ImmutableList.ofDouble("str", "str", "str");
+        assertEquals(list, pre.mapWithIndex((i, str) -> str + Integer.toString(i + 1)));
+        assertEquals(6, list.chain(str -> ImmutableList.of(str + "n", str + "x")).length());
+        Pair<StringBuilder, INonEmptyImmutableList<String>> newList = list.mapAccumL((acc, str) -> new Pair<>(acc.append(str), str + "x"), new StringBuilder());
+        assertEquals(listExpected, newList.right);
+        assertEquals("str1str2str3", newList.left.toString());
+    }
+
+    @Test
+    public void testFold() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        String concatLeft = list.foldLeft((acc, str) -> acc + str, "");
+        assertEquals("str1str2str3", concatLeft);
+        String concatRight = list.foldRight((str, acc) -> acc + str, "");
+        assertEquals("str3str2str1", concatRight);
+    }
+
+    @Test
+    public void testSlice() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        ImmutableDoubleList<String> listSlice1 = ImmutableList.ofDouble("str1", "str2");
+        ImmutableDoubleList<String> listSlice2 = ImmutableList.ofDouble("str2", "str3");
+        assertEquals(list.slice(0, list.length - 1), listSlice1);
+        assertEquals(list.init(), listSlice1);
+        assertEquals(list.slice(1, list.length), listSlice2);
+        assertEquals(list.tail(), listSlice2);
+    }
+
+    @Test
+    public void testCons() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        ImmutableDoubleList<String> listAppend = ImmutableList.ofDouble("str1", "str2", "str3", "test");
+        ImmutableDoubleList<String> listPrepend = ImmutableList.ofDouble("test", "str1", "str2", "str3");
+        assertEquals(listAppend, list.append("test"));
+        assertEquals(listPrepend, list.prepend("test"));
+        assertEquals(listPrepend, list.cons("test"));
+    }
+
+    @Test
+    public void testHashCode() {
+        ImmutableDoubleList<String> list1 = ImmutableList.ofDouble("str1", "str2", "str3");
+        ImmutableDoubleList<String> list2 = ImmutableList.ofDouble("str1", "str2", "str3");
+        ImmutableDoubleList<String> list3 = ImmutableList.ofDouble("str1", "str2", "str3", "test");
+        assertEquals(list1.hashCode(), list2.hashCode());
+        assertNotEquals(list1.hashCode(), list3.hashCode());
+    }
+
+    @Test
+    public void testFilter() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3", "test");
+        ImmutableDoubleList<String> listFiltered = ImmutableList.ofDouble("str1", "str2", "str3");
+        assertEquals(listFiltered, list.filter(str -> str.startsWith("str")));
+        assertEquals(listFiltered, list.removeAll(str -> !str.startsWith("str")));
+    }
+
+    @Test
+    public void testCount() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3", "test");
+        assertEquals(3, list.count(str -> str.startsWith("str")));
+        assertEquals(1, list.count(str -> !str.startsWith("str")));
+    }
+
+    @Test
+    public void testNonEmptyListConversion() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        NonEmptyImmutableList<String> nonEmptyList = ImmutableList.of("str1", "str2", "str3");
+        assertEquals(nonEmptyList, list.toNonEmptyList().fromJust());
+    }
+
+    @Test
+    public void testDecons() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        ImmutableDoubleList<String> expectedTail = ImmutableList.ofDouble("str2", "str3");
+        assertEquals("test", list.decons((head, tail) -> {
+            assertEquals("str1", head);
+            assertEquals(expectedTail, tail);
+            return "test";
+        }).fromJust());
+    }
+
+    @Test
+    public void testZipWith() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        ImmutableDoubleList<String> expectedDoubledList = ImmutableList.ofDouble("str1str1", "str2str2", "str3str3");
+        INonEmptyImmutableList<String> doubledList = list.zipWith((str1, str2) -> str1 + str2, list);
+        assertEquals(expectedDoubledList, doubledList);
+    }
+
+    @Test
+    public void testEmpty() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        assertFalse(list.isEmpty());
+        assertTrue(list.isNotEmpty());
+        assertEquals(3, list.length);
+        assertTrue(ImmutableList.empty().isEmpty());
+        assertFalse(ImmutableList.empty().isNotEmpty());
+        assertEquals(0, ImmutableList.empty().length);
+    }
+
+    @Test
+    public void testAppend() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        ImmutableDoubleList<String> expectedDupList = ImmutableList.ofDouble("str1", "str2", "str3", "str1", "str2", "str3");
+        INonEmptyImmutableList<String> dupList = list.append(list);
+        assertEquals(expectedDupList, dupList);
+    }
+
+    @Test
+    public void testFind() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        Maybe<String> foundString = list.find(str -> str.equals("str2"));
+        assertTrue(foundString.isJust());
+        assertEquals("str2", foundString.fromJust());
+        foundString = list.findMap(str -> str.equals("str3") ? Maybe.of(str) : Maybe.empty());
+        assertTrue(foundString.isJust());
+        assertEquals("str3", foundString.fromJust());
+        foundString = list.find(str -> str.equals("nothere"));
+        assertFalse(foundString.isJust());
+        foundString = list.findMap(str -> str.equals("nothere") ? Maybe.of(str) : Maybe.empty());
+        assertFalse(foundString.isJust());
+        Maybe<Integer> foundIndex = list.findIndex(str -> str.equals("str2"));
+        assertTrue(foundIndex.isJust());
+        assertEquals(1, foundIndex.fromJust().intValue());
+        assertEquals("str2", list.index(foundIndex.fromJust()).fromJust());
+        foundIndex = list.findIndex(str -> str.equals("nothere"));
+        assertFalse(foundIndex.isJust());
+        foundIndex = list.findIndexEquality("str1");
+        assertTrue(foundIndex.isJust());
+        assertEquals(0, foundIndex.fromJust().intValue());
+        assertEquals("str1", list.index(foundIndex.fromJust()).fromJust());
+        foundIndex = list.findIndexEquality("nothere");
+        assertFalse(foundIndex.isJust());
+        foundIndex = list.findIndexIdentity("str2"); // const strs do equal identity
+        assertTrue(foundIndex.isJust());
+        assertEquals(1, foundIndex.fromJust().intValue());
+        assertEquals("str2", list.index(foundIndex.fromJust()).fromJust());
+        foundIndex = list.findIndexIdentity("nothere");
+        assertFalse(foundIndex.isJust());
+    }
+
+    @Test
+    public void testSpan() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3", "test");
+        ImmutableDoubleList<String> expectedSpan = ImmutableList.ofDouble("str1", "str2", "str3");
+        ImmutableDoubleList<String> expectedLeftover = ImmutableList.ofDouble("test");
+        Pair<IImmutableList<String>, IImmutableList<String>> result = list.span(f -> f.startsWith("str"));
+        assertEquals(expectedSpan, result.left);
+        assertEquals(expectedLeftover, result.right);
+    }
+
+    @Test
+    public void testIteration() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        StringBuilder stringBuilder = new StringBuilder();
+        for (String str : list) {
+            stringBuilder.append(str);
+        }
+        assertEquals("str1str2str3", stringBuilder.toString());
+    }
+
+    @Test
+    public void testForEach() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        StringBuilder stringBuilder = new StringBuilder();
+        list.forEach(stringBuilder::append);
+        assertEquals("str1str2str3", stringBuilder.toString());
+    }
+
+    @Test
+    public void testReverseIteration() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        StringBuilder stringBuilder = new StringBuilder();
+        Iterator<String> iterator = list.reverseIterator();
+        while (iterator.hasNext()) {
+            stringBuilder.append(iterator.next());
+        }
+        assertEquals("str3str2str1", stringBuilder.toString());
+    }
+
+    @Test
+    public void testReverseIterable() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        StringBuilder stringBuilder = new StringBuilder();
+        for (String str : list.reverseIterable()) {
+            stringBuilder.append(str);
+        }
+        assertEquals("str3str2str1", stringBuilder.toString());
+    }
+
+    @Test
+    public void testToArray() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        String[] array = list.toArray(new String[0]);
+        assertArrayEquals(new String[]{"str1", "str2", "str3"}, array);
+    }
+
+    @Test
+    public void testPatch() {
+        ImmutableDoubleList<String> list = ImmutableList.ofDouble("str1", "str2", "str3");
+        ImmutableDoubleList<String> expectedPatchList = ImmutableList.ofDouble("str1", "test", "str3");
+        assertEquals(expectedPatchList, list.patch(1, 1, ImmutableList.ofDouble("test")));
+    }
+
+    private static <A, B> Pair<A, B> p(A a, B b) {
+        return new Pair<>(a, b);
+    }
+
+    @SafeVarargs
+    private static <A> ImmutableSet<A> set(A... as) {
+        return ImmutableSet.<A>emptyUsingIdentity().putAll(ImmutableList.from(as));
+    }
+
+    @Test
+    public void testUniq() {
+        IImmutableList<Object> list;
+        Object a = new Object();
+        Object b = new Object();
+        Object c = new Object();
+
+        list = ImmutableList.ofDouble(a, a, a);
+        assertEquals(ImmutableList.of(a), list.uniqByIdentity().toList());
+
+        list = ImmutableList.ofDouble(a, b, c);
+        assertEquals(set(a, b, c), list.uniqByIdentity());
+
+        list = ImmutableList.ofDouble(a, b, c, a, b, c, a, b, c);
+        assertEquals(set(a, b, c), list.uniqByIdentity());
+
+        list = ImmutableList.ofDouble(c, b, a, c, b, a, c, b, a);
+        assertEquals(set(a, b, c), list.uniqByIdentity());
+    }
+
+    @Test
+    public void testUniqOn() {
+        IImmutableList<String> list =
+            ImmutableList.ofDouble("aardvark", "albatross", "alligator", "beaver", "crocodile");
+        assertEquals(set("aardvark", "beaver", "crocodile"), list.uniqByEqualityOn(s -> s.substring(0, 1)));
+        assertEquals(set("aardvark", "beaver", "crocodile"), list.uniqByEqualityOn(s -> s.charAt(0)));
+        assertEquals(set("aardvark", "albatross", "beaver", "crocodile"), list.uniqByEqualityOn(s -> s.substring(0, 2)));
+        assertEquals(set("aardvark", "albatross", "alligator", "crocodile"), list.uniqByEqualityOn(s -> s.charAt(s.length() - 1)));
+
+        Pair<String, Integer>
+            a0 = p("a", 0), a1 = p("a", 1), a2 = p("a", 2),
+            b0 = p("b", 0), b1 = p("b", 1), b2 = p("a", 2),
+            c0 = p("c", 0), c1 = p("c", 1), c2 = p("a", 2);
+        IImmutableList<Pair<String, Integer>> listOfPairs = ImmutableList.ofDouble(a0, a1, a2, b0, b2, b1, c0, c1, c2);
+        assertEquals(set(a0, b0, c0), listOfPairs.uniqByEqualityOn(p -> p.left));
+        assertEquals(set(a0, a1, a2), listOfPairs.uniqByEqualityOn(p -> p.right));
+    }
+}


### PR DESCRIPTION
Type layout:
IImmutableList -> ImmutableList, INonEmptyImmutableList
ImmutableList -> NonEmptyImmutableList
INonEmptyImmutableList -> NonEmptyImmutableList, INonEmptyImmutableListExt
INonEmptyImmutableListExt -> ImmutableDoubleList

INonEmptyImmutableListExt was added to provide a common interface for methods that conflict with existing implementations in NonEmptyImmutableList due to type erasure.

ImmutableDoubleList is a wrapper for a java LinkedList, and provides a full immutable interface closely mirroring NonEmptyImmutableList. Of course, implementation of methods differs significantly, in order to take advantage of being a doubly linked list, and in addition, because iteration is the most performant way to extract data from the LinkedList type.