### PR TITLE
Track hashcode for ImmutableList, version 2.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity</groupId>
     <artifactId>shape-functional-java</artifactId>
-    <version>2.5.3</version>
+    <version>2.5.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Shape Functional Java</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity</groupId>
     <artifactId>shape-functional-java</artifactId>
-    <version>2.5.3-SNAPSHOT</version>
+    <version>2.5.3</version>
     <packaging>jar</packaging>
 
     <name>Shape Functional Java</name>

--- a/pom.xml
+++ b/pom.xml
@@ -106,29 +106,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.2.201409121644</version>
-                <executions>
-                    <execution>
-                        <id>pre-unit-test</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>JACOCO_AGENT_OPT</propertyName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>post-unit-test</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
@@ -168,7 +145,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration><!-- Sets the VM argument line used when unit tests are run. -->
-                    <argLine>${JACOCO_AGENT_OPT}</argLine>
                     <excludes>
                         <exclude>**/BenchmarkTest.java</exclude>
                     </excludes>

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
@@ -205,6 +205,14 @@ public abstract class ImmutableList<A> implements Iterable<A> {
         }
     }
 
+    protected final Integer getCachedHashCode() {
+        return this.hashCode;
+    }
+
+    protected final void setCachedHashCode(Integer hashCode) {
+        this.hashCode = hashCode;
+    }
+
     /**
      * This function is provided by Iterable that can be used to avoid a creation
      * of an Iterator instance.

--- a/src/test/java/com/shapesecurity/functional/data/NonEmptyImmutableListTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/NonEmptyImmutableListTest.java
@@ -181,4 +181,25 @@ public class NonEmptyImmutableListTest extends TestBase {
         assertEquals(set(a0, b0, c0), listOfPairs.uniqByEqualityOn(p -> p.left));
         assertEquals(set(a0, a1, a2), listOfPairs.uniqByEqualityOn(p -> p.right));
     }
+
+    @Test
+    public void testHashCode() {
+        ImmutableList<String> list1 =
+                ImmutableList.of("aardvark", "albatross", "alligator", "beaver", "crocodile");
+        ImmutableList<String> list2 =
+                ImmutableList.of("aardvark", "albatross", "alligator", "beaver", "crocodile");
+        assertEquals(list1.hashCode(), list2.hashCode());
+        ImmutableList<String> list3 = list1.maybeTail().fromJust();
+        ImmutableList<String> list4 = list2.maybeTail().fromJust();
+        assertEquals(list3.hashCode(), list4.hashCode());
+        assertNotEquals(list1.hashCode(), list3.hashCode());
+        assertEquals(list3.cons("test").hashCode(), list4.cons("test").hashCode());
+        assertEquals(list3.cons("aardvark").hashCode(), list1.hashCode());
+
+        ImmutableList<String> list5 =
+                ImmutableList.of("albatross", "alligator", "beaver", "crocodile");
+        int hashCode1 = list5.hashCode();
+        assertEquals(list1.hashCode(), list5.cons("aardvark").hashCode());
+        assertEquals(hashCode1, list5.hashCode());
+    }
 }


### PR DESCRIPTION
Removes `hashCode` caching in place of gradual calculation to reduce massive recursion when calculating an uncached `hashCode` for long lists. Caching is done implicitly.

Contains version bump, rebase not squash.