### PR TITLE
General improvements/tweaks to HashTable, ImmutableSet, and ImmutableList

### DIFF
--- a/src/main/java/com/shapesecurity/functional/Pair.java
+++ b/src/main/java/com/shapesecurity/functional/Pair.java
@@ -71,6 +71,16 @@ public final class Pair<A, B> {
     }
 
     @Nonnull
+    public <A1, B1> Pair<A1, B1> map(@Nonnull F<A, A1> fA, @Nonnull F<B, B1> fB) {
+        return new Pair<>(fA.apply(this.left), fB.apply(this.right));
+    }
+
+    @Nonnull
+    public <T> T map(@Nonnull F2<A, B, T> f) {
+        return f.apply(this.left, this.right);
+    }
+
+    @Nonnull
     public <A1> Pair<A1, B> mapLeft(@Nonnull F<A, A1> f) {
         return new Pair<>(f.apply(this.left), this.right);
     }

--- a/src/main/java/com/shapesecurity/functional/Tuple3.java
+++ b/src/main/java/com/shapesecurity/functional/Tuple3.java
@@ -30,6 +30,21 @@ public final class Tuple3<A, B, C> {
     @Nonnull
     public final C c;
 
+    /**
+     * Constructor method to utilize type inference.
+     * @param a first component
+     * @param b second component
+     * @param c third component
+     * @param <A> type of the first component
+     * @param <B> type of the second component
+     * @param <C> type of the third component
+     * @return the pair
+     */
+    @Nonnull
+    public static <A, B, C> Tuple3<A, B, C> of(A a, B b, C c) {
+        return new Tuple3<>(a, b, c);
+    }
+
     public Tuple3(@Nonnull A a, @Nonnull B b, @Nonnull C c) {
         super();
         this.a = a;

--- a/src/main/java/com/shapesecurity/functional/Tuple4.java
+++ b/src/main/java/com/shapesecurity/functional/Tuple4.java
@@ -32,6 +32,23 @@ public final class Tuple4<A, B, C, D> {
     @Nonnull
     public final D d;
 
+    /**
+     * Constructor method to utilize type inference.
+     * @param a first component
+     * @param b second component
+     * @param c third component
+     * @param d fourth component
+     * @param <A> type of the first component
+     * @param <B> type of the second component
+     * @param <C> type of the third component
+     * @param <D> type of the fourth component
+     * @return the pair
+     */
+    @Nonnull
+    public static <A, B, C, D> Tuple4<A, B, C, D> of(A a, B b, C c, D d) {
+        return new Tuple4<>(a, b, c, d);
+    }
+
     public Tuple4(@Nonnull A a, @Nonnull B b, @Nonnull C c, @Nonnull D d) {
         super();
         this.a = a;

--- a/src/main/java/com/shapesecurity/functional/data/HashTable.java
+++ b/src/main/java/com/shapesecurity/functional/data/HashTable.java
@@ -135,24 +135,27 @@ public abstract class HashTable<K, V> implements Iterable<Pair<K, V>> {
     }
 
     @Nonnull
+    public static <K, V> HashTable<K, V> fromUsingEquality(@Nonnull ImmutableList<Pair<K, V>> list) {
+        return HashTable.<K, V>emptyUsingEquality().putAll(list);
+    }
+
+    @Nonnull
+    public static <K, V> HashTable<K, V> fromUsingIdentity(@Nonnull ImmutableList<Pair<K, V>> list) {
+        return HashTable.<K, V>emptyUsingIdentity().putAll(list);
+    }
+
+    @Nonnull
+    public static <K, V> HashTable<K, V> from(@Nonnull Hasher<K> hasher, @Nonnull ImmutableList<Pair<K, V>> list) {
+        return HashTable.<K, V>empty(hasher).putAll(list);
+    }
+
+    @Nonnull
     public final HashMap<K, V> toHashMap() {
         HashMap<K, V> map = new HashMap<>();
         for (Pair<K, V> pair : this) {
             map.put(pair.left, pair.right);
         }
         return map;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Nonnull
-    public final <A, B> HashTable<A, B> mapEntries(F<Pair<K, V>, Pair<A, B>> f) {
-        return this.foldLeft((acc, pair) -> acc.put(f.apply(pair)), empty((Hasher<A>) this.hasher));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Nonnull
-    public final <A, B> HashTable<A, B> flatMapEntries(F<Pair<K, V>, ImmutableList<Pair<A, B>>> f) {
-        return this.foldLeft((acc, pair) -> acc.putAll(f.apply(pair)), empty((Hasher<A>) this.hasher));
     }
 
     @Nonnull

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
@@ -25,11 +25,23 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * An immutable singly linked list implementation. None of the operations in {@link ImmutableList}
@@ -257,6 +269,17 @@ public abstract class ImmutableList<A> implements Iterable<A> {
         };
     }
 
+    @Override
+    public final Spliterator<A> spliterator() {
+        return Spliterators.spliterator(iterator(), this.length, Spliterator.IMMUTABLE | Spliterator.NONNULL);
+    }
+
+    @Nonnull
+    public final Stream<A> stream() {
+        return StreamSupport.stream(this.spliterator(), false);
+    }
+
+
     // Methods
 
     /**
@@ -457,6 +480,22 @@ public abstract class ImmutableList<A> implements Iterable<A> {
     }
 
     /**
+     * Converts this list into a java.util.List.
+     *
+     * @return The list that contains the elements.
+     */
+    @Nonnull
+    public final List<A> toList() {
+        List<A> list = new ArrayList<>(this.length);
+        ImmutableList<A> l = this;
+        for (int i = 0; i < length; i++) {
+            list.add(((NonEmptyImmutableList<A>) l).head);
+            l = ((NonEmptyImmutableList<A>) l).tail;
+        }
+        return list;
+    }
+
+    /**
      * Converts this list into an array. <p> Due to type erasure, the type of the resulting array
      * has to be determined at runtime. Fortunately, you can create a zero length array and this
      * method can create an large enough array to contain all the elements. If the given array is
@@ -558,6 +597,27 @@ public abstract class ImmutableList<A> implements Iterable<A> {
      */
     @Nonnull
     public abstract <B> ImmutableList<B> flatMap(@Nonnull F<A, ImmutableList<B>> f);
+
+    /**
+     *
+     * Apply <code>f</code> to each element of the list, returning false if f is false for an element,
+     * or true if true for all elements.
+     *
+     * @param f The function to test against
+     * @return true IFF f is true for all entries in this list
+     */
+    public abstract boolean all(@Nonnull F<A, Boolean> f);
+
+    /**
+     *
+     * Apply <code>f</code> to each element of the list, returning true if f is true.
+     *
+     * @param f The function to test against
+     * @return true IFF f is true for any entry in this list
+     */
+    public final boolean any(@Nonnull F<A, Boolean> f) {
+        return exists(f);
+    }
 
     public final boolean isNotEmpty() {
         return !this.isEmpty();
@@ -736,5 +796,48 @@ public abstract class ImmutableList<A> implements Iterable<A> {
         }
         return Pair.of(fromBounded(result, 0, l[0]), right);
     }
+
+    @Nonnull
+    public static <T> Collector<T, ?, ImmutableList<T>> collector() {
+        return new Collector<T, ArrayList<T>, ImmutableList<T>>() {
+            @Override
+            public Supplier<ArrayList<T>> supplier() {
+                return ArrayList::new;
+            }
+
+            @Override
+            public BiConsumer<ArrayList<T>, T> accumulator() {
+                return ArrayList::add;
+            }
+
+            @Override
+            public BinaryOperator<ArrayList<T>> combiner() {
+                return (left, right) -> {
+                    left.addAll(right);
+                    return left;
+                };
+            }
+
+            @Override
+            public Function<ArrayList<T>, ImmutableList<T>> finisher() {
+                return ImmutableList::from;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return new HashSet<>();
+            }
+        };
+    }
+
+    /*
+    public static <T>
+    Collector<T, ?, List<T>> toList() {
+        return new CollectorImpl<>((Supplier<List<T>>) ArrayList::new, List::add,
+                                   (left, right) -> { left.addAll(right); return left; },
+                                   CH_ID);
+    }
+
+     */
 }
 

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -7,7 +7,19 @@ import com.shapesecurity.functional.Unit;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 @CheckReturnValue
 public class ImmutableSet<T> implements Iterable<T> {
@@ -22,28 +34,61 @@ public class ImmutableSet<T> implements Iterable<T> {
         this.data = data;
     }
 
+    @Nonnull
     public static <T> ImmutableSet<T> empty(@Nonnull Hasher<T> hasher) {
         return new ImmutableSet<>(HashTable.empty(hasher));
     }
 
+    @Nonnull
     public static <T> ImmutableSet<T> emptyUsingEquality() {
         return new ImmutableSet<>(HashTable.emptyUsingEquality());
     }
 
+    @Nonnull
     public static <T> ImmutableSet<T> emptyUsingIdentity() {
         return new ImmutableSet<>(HashTable.emptyUsingIdentity());
     }
 
+    @Nonnull
+    @SafeVarargs
+    public static <T> ImmutableSet<T> ofUsingIdentity(@Nonnull T... items) {
+        return ImmutableSet.<T>emptyUsingIdentity().putAll(items);
+    }
+
+    @Nonnull
+    @SafeVarargs
+    public static <T> ImmutableSet<T> ofUsingEquality(@Nonnull T... items) {
+        return ImmutableSet.<T>emptyUsingEquality().putAll(items);
+    }
+
+    @Nonnull
+    public static <T> ImmutableSet<T> from(@Nonnull Hasher<T> hasher, @Nonnull Set<T> set) {
+        return empty(hasher).union(set);
+    }
+
+    @Nonnull
+    public static <T> ImmutableSet<T> fromUsingEquality(@Nonnull Set<T> set) {
+        return ImmutableSet.<T>emptyUsingEquality().union(set);
+    }
+
+    @Nonnull
+    public static <T> ImmutableSet<T> fromUsingIdentity(@Nonnull Set<T> set) {
+        return ImmutableSet.<T>emptyUsingIdentity().union(set);
+    }
+
     @Deprecated
+    @Nonnull
     public static <T> ImmutableSet<T> empty() {
         return ImmutableSet.emptyUsingEquality();
     }
 
     @Deprecated
+    @Nonnull
     public static <T> ImmutableSet<T> emptyP() {
         return ImmutableSet.emptyUsingIdentity();
     }
 
+    @Nonnull
     public <B extends T> ImmutableSet<T> put(@Nonnull B datum) {
         return new ImmutableSet<>(this.data.put(datum, Unit.unit));
     }
@@ -53,30 +98,68 @@ public class ImmutableSet<T> implements Iterable<T> {
         return list.foldLeft(ImmutableSet::put, this);
     }
 
+    @Nonnull
+    public <B extends T> ImmutableSet<T> putAll(@Nonnull B... list) {
+        ImmutableSet<T> set = this;
+        for (B b : list) {
+            set = set.put(b);
+        }
+        return set;
+    }
+
     public boolean contains(@Nonnull T datum) {
         return this.data.containsKey(datum);
     }
 
-    @SuppressWarnings("unchecked")
+    @Nonnull
     public <A> ImmutableSet<A> map(@Nonnull F<T, A> f) {
-        return this.foldAbelian((val, acc) -> acc.put(f.apply(val)), ImmutableSet.empty((Hasher<A>) this.data.hasher));
+        return new ImmutableSet<>(this.data.mapEntries(pair -> Pair.of(f.apply(pair.left), pair.right)));
+    }
+
+    @Nonnull
+    public <A> ImmutableSet<A> flatMap(@Nonnull F<T, ImmutableList<A>> f) {
+        return new ImmutableSet<>(this.data.flatMapEntries(pair -> f.apply(pair.left).map(a -> Pair.of(a, Unit.unit))));
+    }
+
+    @Nonnull
+    public ImmutableSet<T> filter(@Nonnull F<T, Boolean> f) {
+        return new ImmutableSet<>(this.data.filter(pair -> f.apply(pair.left)));
     }
 
     public ImmutableSet<T> remove(@Nonnull T datum) {
         return new ImmutableSet<>(this.data.remove(datum));
     }
 
+    @Nonnull
     public <A> A foldAbelian(@Nonnull F2<T, A, A> f, @Nonnull A init) {
         return this.data.foldRight((p, acc) -> f.apply(p.left, acc), init);
     }
 
+    @Nonnull
     public ImmutableSet<T> union(@Nonnull ImmutableSet<T> other) {
         return new ImmutableSet<>(this.data.merge(other.data));
     }
 
+    @Nonnull
+    public ImmutableSet<T> union(@Nonnull Set<T> other) {
+        ImmutableSet<T> set = this;
+        for (T entry : other) {
+            set = set.put(entry);
+        }
+        return set;
+    }
+
     // Does not guarantee ordering of elements in resulting list.
+    @Nonnull
     public ImmutableList<T> toList() {
         return this.foldAbelian((v, acc) -> acc.cons(v), ImmutableList.empty());
+    }
+
+    @Nonnull
+    public Set<T> toHashSet() {
+        Set<T> set = new HashSet<>();
+        this.forEach(set::add);
+        return set;
     }
 
     @SuppressWarnings("unchecked")
@@ -86,6 +169,7 @@ public class ImmutableSet<T> implements Iterable<T> {
     }
 
     @Override
+    @Nonnull
     public Iterator<T> iterator() {
         final Iterator<Pair<T, Unit>> mapIterator = this.data.iterator();
         return new Iterator<T>() {
@@ -97,6 +181,58 @@ public class ImmutableSet<T> implements Iterable<T> {
             @Override
             public T next() {
                 return mapIterator.next().left;
+            }
+        };
+    }
+
+    @Nonnull
+    @Override
+    public final Spliterator<T> spliterator() {
+        return Spliterators.spliterator(this.iterator(), this.length(), Spliterator.IMMUTABLE | Spliterator.NONNULL);
+    }
+
+    @Nonnull
+    public final Stream<T> stream() {
+        return StreamSupport.stream(this.spliterator(), false);
+    }
+
+    @Nonnull
+    public <V> HashTable<T, V> mapToTable(@Nonnull F<T, V> f) {
+        return this.data.mapEntries(pair -> Pair.of(pair.left, f.apply(pair.left)));
+    }
+
+
+    @Nonnull
+    public static <T> Collector<T, ?, ImmutableSet<T>> collector() {
+        return new Collector<T, Set<T>, ImmutableSet<T>>() {
+            @Override
+            public Supplier<Set<T>> supplier() {
+                return HashSet::new;
+            }
+
+            @Override
+            public BiConsumer<Set<T>, T> accumulator() {
+                return Set::add;
+            }
+
+            @Override
+            public BinaryOperator<Set<T>> combiner() {
+                return (left, right) -> {
+                    left.addAll(right);
+                    return left;
+                };
+            }
+
+            @Override
+            public Function<Set<T>, ImmutableSet<T>> finisher() {
+                return ImmutableSet::fromUsingEquality;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                Set<Characteristics> set = new HashSet<>();
+                set.add(Characteristics.UNORDERED);
+                return set;
             }
         };
     }

--- a/src/main/java/com/shapesecurity/functional/data/Nil.java
+++ b/src/main/java/com/shapesecurity/functional/data/Nil.java
@@ -165,6 +165,11 @@ public final class Nil<T> extends ImmutableList<T> {
         return (ImmutableList<B>) this;
     }
 
+    @Override
+    public boolean all(@Nonnull F<T, Boolean> f) {
+        return false;
+    }
+
     @Nonnull
     @Override
     public ImmutableList<T> removeAll(@Nonnull F<T, Boolean> f) {

--- a/src/main/java/com/shapesecurity/functional/data/NonEmptyImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/NonEmptyImmutableList.java
@@ -358,6 +358,18 @@ public final class NonEmptyImmutableList<T> extends ImmutableList<T> {
         return from(result);
     }
 
+    @Override
+    public boolean all(@Nonnull F<T, Boolean> f) {
+        ImmutableList<T> list = this;
+        while (list instanceof NonEmptyImmutableList) {
+            if (!f.apply(((NonEmptyImmutableList<T>) list).head)) {
+                return false;
+            }
+            list = ((NonEmptyImmutableList<T>) list).tail;
+        }
+        return true;
+    }
+
     @Nonnull
     @Override
     public ImmutableList<T> removeAll(@Nonnull F<T, Boolean> f) {

--- a/src/test/java/com/shapesecurity/functional/data/HashTableTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/HashTableTest.java
@@ -453,43 +453,6 @@ public class HashTableTest extends TestBase {
     }
 
     @Test
-    public void mapEntriesTest() {
-        HashTable<String, String> map = HashTable.<String, String>emptyUsingEquality()
-            .put("key1", "value1")
-            .put("key2", "value2x")
-            .put("key3", "value3xx");
-        HashTable<String, Integer> mappedMap = map.mapEntries(pair -> pair.map(key -> key.substring(2), String::length));
-        assertEquals(prepareForAssertion(HashTable.<String, Integer>emptyUsingEquality()
-                .put("y1", 6)
-                .put("y2", 7)
-                .put("y3", 8)
-            ),
-            prepareForAssertion(mappedMap)
-        );
-    }
-
-    @Test
-    public void flatMapEntriesTest() {
-        HashTable<String, String> map = HashTable.<String, String>emptyUsingEquality()
-            .put("key1", "value1")
-            .put("key2", "value2x")
-            .put("key3", "value3xx");
-        HashTable<String, Integer> mappedMap = map.flatMapEntries(pair -> pair.map((left, right) ->
-            ImmutableList.of(Pair.of(left.substring(1), right.length()), Pair.of(left.substring(2), right.length()))
-        ));
-        assertEquals(prepareForAssertion(HashTable.<String, Integer>emptyUsingEquality()
-                .put("ey1", 6)
-                .put("ey2", 7)
-                .put("ey3", 8)
-                .put("y1", 6)
-                .put("y2", 7)
-                .put("y3", 8)
-            ),
-            prepareForAssertion(mappedMap)
-        );
-    }
-
-    @Test
     public void filterTest() {
         HashTable<String, String> map = HashTable.<String, String>emptyUsingEquality()
             .put("key1", "value1")

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
@@ -17,6 +17,8 @@
 package com.shapesecurity.functional.data;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.shapesecurity.functional.Effect;
 import com.shapesecurity.functional.Pair;
@@ -300,6 +302,18 @@ public class ImmutableListTest extends TestBase {
     public void testExists() {
         ImmutableList<Integer> list = ImmutableList.empty();
         assertFalse(list.contains(0));
+        list = list.cons(10);
+        assertTrue(list.exists(integer -> integer % 5 == 0));
+        assertTrue(list.any(integer -> integer == 10));
+        assertFalse(list.any(integer -> integer == 11));
+    }
+
+    @Test
+    public void testAll() {
+        ImmutableList<Integer> list = ImmutableList.of(5, 10, 15, 20);
+        assertTrue(list.all(integer -> integer % 5 == 0));
+        list = list.cons(1);
+        assertFalse(list.all(integer -> integer % 5 == 0));
     }
 
     @Test
@@ -372,5 +386,22 @@ public class ImmutableListTest extends TestBase {
         assertTrue(ImmutableList.of(0, 1).findIndex(i -> i == 1).fromJust() == 1);
         assertTrue(ImmutableList.of(0, 1, 1).findIndex(i -> i == 1).fromJust() == 1);
         assertTrue(ImmutableList.of(0, 1).findIndex(i -> i == 2).isNothing());
+    }
+
+    @Test
+    public void testStream() {
+        ImmutableList<Integer> list = ImmutableList.of(1, 2, 3, 4, 5);
+        List<Integer> mutableList = list.stream().collect(Collectors.toList());
+        assertEquals(mutableList, list.toList());
+        mutableList.sort((int1, int2) -> int2 - int1); // reversed
+
+        assertEquals(list.reverse(), ImmutableList.from(mutableList));
+        assertEquals(mutableList, list.stream().sorted((int1, int2) -> int2 - int1).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testCollector() {
+        ImmutableList<Integer> list = ImmutableList.of(1, 2, 3, 4, 5);
+        assertEquals(list, list.stream().map(x -> x + 1).map(x -> x - 1).collect(ImmutableList.collector()));
     }
 }

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
@@ -18,10 +18,15 @@ package com.shapesecurity.functional.data;
 
 import com.shapesecurity.functional.Pair;
 import com.shapesecurity.functional.TestBase;
-import com.shapesecurity.functional.Unit;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -82,6 +87,107 @@ public class ImmutableSetTest extends TestBase {
 
         ImmutableSet<String> expected = range(0, N).foldLeft((acc, i) -> acc.put(Integer.toString(i) + "_test"), ImmutableSet.emptyUsingEquality());
         assertEquals(expected, mapped);
+    }
+
+    @Nonnull
+    private static List<String> prepareForAssertion(@Nonnull ImmutableSet<String> set) {
+        List<String> list = set.toList().toList();
+        list.sort(String::compareTo);
+        return list;
+    }
+
+    @Nonnull
+    private static List<String> prepareForAssertion(@Nonnull Set<String> set) {
+        List<String> list = new ArrayList<>(set);
+        list.sort(String::compareTo);
+        return list;
+    }
+
+    @Test
+    public void mutableRoundTripTest() {
+        ImmutableSet<String> expected = ImmutableSet.<String>emptyUsingEquality()
+            .put("key1")
+            .put("key2")
+            .put("key3");
+        Set<String> set = new HashSet<>();
+        set.add("key1");
+        set.add("key2");
+        set.add("key3");
+        ImmutableSet<String> table = ImmutableSet.fromUsingEquality(set);
+        assertEquals(prepareForAssertion(expected), prepareForAssertion(table));
+        ImmutableSet<String> doubledSet = table.union(set);
+        assertEquals(prepareForAssertion(table), prepareForAssertion(doubledSet));
+        set.add("key4");
+        expected = expected.put("key4");
+        assertEquals(prepareForAssertion(expected), prepareForAssertion(table.union(set)));
+        assertEquals(prepareForAssertion(set), prepareForAssertion(expected.toHashSet()));
+    }
+
+    @Test
+    public void flatMapTest() {
+        ImmutableSet<String> expected = ImmutableSet.<String>emptyUsingEquality()
+            .put("key1")
+            .put("key2")
+            .put("key3");
+        ImmutableSet<String> mappedSet = expected.flatMap(string -> ImmutableList.of(string + "1", string + "2"));
+        assertEquals(prepareForAssertion(ImmutableSet.<String>emptyUsingEquality()
+                .put("key11")
+                .put("key21")
+                .put("key31")
+                .put("key12")
+                .put("key22")
+                .put("key32")
+            ),
+            prepareForAssertion(mappedSet)
+        );
+    }
+
+    @Test
+    public void filterTest() {
+        ImmutableSet<String> expected = ImmutableSet.<String>emptyUsingEquality()
+            .put("key1")
+            .put("key2")
+            .put("keyx2")
+            .put("key3");
+        ImmutableSet<String> filteredSet = expected.filter(string -> string.endsWith("2"));
+        assertEquals(prepareForAssertion(ImmutableSet.<String>emptyUsingEquality()
+                .put("key2")
+                .put("keyx2")
+            ),
+            prepareForAssertion(filteredSet)
+        );
+    }
+
+    @Test
+    public void mapToTableTest() {
+        ImmutableSet<String> set = ImmutableSet.<String>emptyUsingEquality()
+            .put("key1")
+            .put("key2")
+            .put("key3");
+        HashTable<String, String> table = set.mapToTable(key -> key.replace("key", "value"));
+
+        assertEquals(HashTableTest.prepareForAssertion(HashTable.<String, String>emptyUsingEquality()
+                .put("key1", "value1")
+                .put("key2", "value2")
+                .put("key3", "value3")
+            ),
+            HashTableTest.prepareForAssertion(table)
+        );
+    }
+
+    @Test
+    public void testStream() {
+        ImmutableSet<Integer> set = ImmutableSet.ofUsingEquality(1, 2, 3, 4, 5);
+        List<Integer> mutableList = set.stream().sorted().collect(Collectors.toList());
+        List<Integer> mutableListFromList = set.toList().toList();
+        mutableListFromList.sort(Integer::compareTo);
+        assertEquals(mutableList, mutableListFromList);
+    }
+
+    @Test
+    public void testCollector() {
+        ImmutableSet<String> set = ImmutableSet.ofUsingEquality("1", "2", "3", "4", "5");
+        assertEquals(prepareForAssertion(set), prepareForAssertion(set.stream().map(x -> x + "").collect(ImmutableSet.collector())));
     }
 
     @Test

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
@@ -129,7 +129,7 @@ public class ImmutableSetTest extends TestBase {
             .put("key1")
             .put("key2")
             .put("key3");
-        ImmutableSet<String> mappedSet = expected.flatMap(string -> ImmutableList.of(string + "1", string + "2"));
+        ImmutableSet<String> mappedSet = expected.flatMap(string -> ImmutableSet.of(string + "1", string + "2"));
         assertEquals(prepareForAssertion(ImmutableSet.<String>emptyUsingEquality()
                 .put("key11")
                 .put("key21")


### PR DESCRIPTION
Fixes #72, #71, #68, #67, #66, #64.

Also adds some new `map` methods to `Pair`, `Collector` providing methods for `ImmutableSet` and `ImmutableList`, some extra mutable type translation methods.