### PR TITLE
add HashTable.orderedEntries

### DIFF
--- a/src/main/java/com/shapesecurity/functional/data/HashTable.java
+++ b/src/main/java/com/shapesecurity/functional/data/HashTable.java
@@ -27,6 +27,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -243,6 +245,16 @@ public abstract class HashTable<K, V> implements Iterable<Pair<K, V>> {
         int[] i = new int[1];
         this.forEach(x -> pairs[i[0]++] = x);
         return ImmutableList.from(pairs);
+    }
+
+    @Nonnull
+    public ImmutableList<Pair<K, V>> orderedEntries(Comparator<? super K> comparator) {
+        ArrayList<Pair<K, V>> entries = new ArrayList<>(this.length);
+        for (Pair<K, V> entry : this) {
+            entries.add(entry);
+        }
+        entries.sort((e1, e2) -> comparator.compare(e1.left, e2.left));
+        return ImmutableList.from(entries);
     }
 
     public final void foreach(@Nonnull Effect<Pair<K, V>> e) {

--- a/src/test/java/com/shapesecurity/functional/data/HashTableTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/HashTableTest.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Comparator;
 
 import static org.junit.Assert.*;
 
@@ -498,4 +499,27 @@ public class HashTableTest extends TestBase {
         );
     }
 
+    @Test
+    public void orderedEntriesTest() {
+        class Wrapper {
+            private final double wrapped;
+            private Wrapper(double wrapped) {
+                this.wrapped = wrapped;
+            }
+        }
+        int N = 1000;
+        HashTable<Double, Wrapper> t = HashTable.emptyUsingEquality();
+        for (int i = 0; i < N; ++i) {
+            double x = Math.random();
+            t = t.put(x, new Wrapper(x));
+        }
+        double previous = -1;
+        ImmutableList<Pair<Double, Wrapper>> sorted = t.orderedEntries(Comparator.naturalOrder());
+        assertEquals(sorted.length, N);
+        for (Pair<Double, Wrapper> pair : sorted) {
+            assertEquals(pair.left, pair.right.wrapped, 0);
+            assertTrue(pair.left >= previous);
+            previous = pair.left;
+        }
+    }
 }


### PR DESCRIPTION
HashTable iteration is inherently unordered. But when the keys can be ordered, it's nice to be able to do things according to that order.