### PR TITLE
Hashtable mutable interfacing

### DIFF
--- a/src/main/java/com/shapesecurity/functional/data/HashTable.java
+++ b/src/main/java/com/shapesecurity/functional/data/HashTable.java
@@ -25,7 +25,9 @@ import com.shapesecurity.functional.Unit;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 
@@ -118,6 +120,30 @@ public abstract class HashTable<K, V> implements Iterable<Pair<K, V>> {
     }
 
     @Nonnull
+    public static <K, V> HashTable<K, V> fromUsingEquality(@Nonnull Map<K, V> map) {
+        return HashTable.<K, V>emptyUsingEquality().merge(map);
+    }
+
+    @Nonnull
+    public static <K, V> HashTable<K, V> fromUsingIdentity(@Nonnull Map<K, V> map) {
+        return HashTable.<K, V>emptyUsingIdentity().merge(map);
+    }
+
+    @Nonnull
+    public static <K, V> HashTable<K, V> from(@Nonnull Hasher<K> hasher, @Nonnull Map<K, V> map) {
+        return HashTable.<K, V>empty(hasher).merge(map);
+    }
+
+    @Nonnull
+    public final HashMap<K, V> toHashMap() {
+        HashMap<K, V> map = new HashMap<>();
+        for (Pair<K, V> pair : this) {
+            map.put(pair.left, pair.right);
+        }
+        return map;
+    }
+
+    @Nonnull
     public final HashTable<K, V> put(@Nonnull K key, @Nonnull V value) {
         return this.put(key, value, this.hasher.hash(key));
     }
@@ -145,6 +171,15 @@ public abstract class HashTable<K, V> implements Iterable<Pair<K, V>> {
     @Nonnull
     public final HashTable<K, V> merge(@Nonnull HashTable<K, V> tree) {
         return this.merge(tree, (a, b) -> b);
+    }
+
+    @Nonnull
+    public final HashTable<K, V> merge(@Nonnull Map<K, V> map) {
+        HashTable<K, V> table = this;
+        for (Map.Entry<K, V> entry : map.entrySet()) {
+            table = table.put(entry.getKey(), entry.getValue());
+        }
+        return table;
     }
 
     @Nonnull

--- a/src/test/java/com/shapesecurity/functional/data/HashTableTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/HashTableTest.java
@@ -24,6 +24,13 @@ import org.junit.Test;
 
 import javax.annotation.Nonnull;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.*;
 
 public class HashTableTest extends TestBase {
@@ -418,5 +425,33 @@ public class HashTableTest extends TestBase {
             sum += i.right;
         }
         assertEquals(N * N / 4, sum);
+    }
+
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    protected static <V> List<Pair<String, V>> prepareForAssertion(@Nonnull HashTable<String, V> table) {
+        List<Pair<String, V>> list = new ArrayList<>(Arrays.asList(table.entries().toArray((Pair<String, V>[]) new Pair[0])));
+        list.sort(Comparator.comparing(pair -> pair.left));
+        return list;
+    }
+
+    @Test
+    public void mutableRoundTripTest() {
+        HashTable<String, String> expected = HashTable.<String, String>emptyUsingEquality()
+            .put("key1", "value1")
+            .put("key2", "value2")
+            .put("key3", "value3");
+        Map<String, String> map = new HashMap<>();
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        map.put("key3", "value3");
+        HashTable<String, String> table = HashTable.fromUsingEquality(map);
+        assertEquals(prepareForAssertion(expected), prepareForAssertion(table));
+        HashTable<String, String> doubledTable = table.merge(map);
+        assertEquals(prepareForAssertion(table), prepareForAssertion(doubledTable));
+        map.put("key4", "value4");
+        expected = expected.put("key4", "value4");
+        assertEquals(prepareForAssertion(expected), prepareForAssertion(table.merge(map)));
+        assertEquals(map, expected.toHashMap());
     }
 }

--- a/src/test/java/com/shapesecurity/functional/data/HashTableTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/HashTableTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -447,11 +448,21 @@ public class HashTableTest extends TestBase {
         map.put("key3", "value3");
         HashTable<String, String> table = HashTable.fromUsingEquality(map);
         assertEquals(prepareForAssertion(expected), prepareForAssertion(table));
-        HashTable<String, String> doubledTable = table.merge(map);
+        HashTable<String, String> doubledTable = table.putAllFrom(map);
         assertEquals(prepareForAssertion(table), prepareForAssertion(doubledTable));
         map.put("key4", "value4");
         expected = expected.put("key4", "value4");
-        assertEquals(prepareForAssertion(expected), prepareForAssertion(table.merge(map)));
+        assertEquals(prepareForAssertion(expected), prepareForAssertion(table.putAllFrom(map)));
         assertEquals(map, expected.toHashMap());
+
+        IdentityHashMap<Integer, Integer> mapIdentity = new IdentityHashMap<>();
+        mapIdentity.put(1, 2);
+        mapIdentity.put(2, 3);
+        mapIdentity.put(3, 4);
+        HashTable<Integer, Integer> tableIdentity = HashTable.<Integer, Integer>emptyUsingIdentity()
+            .put(1, 2)
+            .put(2, 3)
+            .put(3, 4);
+        assertEquals(mapIdentity, tableIdentity.toIdentityHashMap());
     }
 }


### PR DESCRIPTION
Allows bidirectional conversion of `HashMap` and `HashTable`. Addresses #71.