### PR TITLE
ImmutableList::toList implementation

### DIFF
--- a/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
@@ -458,13 +459,29 @@ public abstract class ImmutableList<A> implements Iterable<A> {
     }
 
     /**
-     * Converts this list into a java.util.List.
+     * Converts this list into a java.util.ArrayList.
      *
      * @return The list that contains the elements.
      */
     @Nonnull
     public final ArrayList<A> toArrayList() {
         ArrayList<A> list = new ArrayList<>(this.length);
+        ImmutableList<A> l = this;
+        for (int i = 0; i < length; i++) {
+            list.add(((NonEmptyImmutableList<A>) l).head);
+            l = ((NonEmptyImmutableList<A>) l).tail;
+        }
+        return list;
+    }
+
+    /**
+     * Converts this list into a java.util.LinkedList.
+     *
+     * @return The list that contains the elements.
+     */
+    @Nonnull
+    public final LinkedList<A> toLinkedList() {
+        LinkedList<A> list = new LinkedList<>();
         ImmutableList<A> l = this;
         for (int i = 0; i < length; i++) {
             list.add(((NonEmptyImmutableList<A>) l).head);

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
@@ -25,6 +25,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -454,6 +455,22 @@ public abstract class ImmutableList<A> implements Iterable<A> {
             l = ((NonEmptyImmutableList<A>) l).tail;
         }
         return target;
+    }
+
+    /**
+     * Converts this list into a java.util.List.
+     *
+     * @return The list that contains the elements.
+     */
+    @Nonnull
+    public final List<A> toList() {
+        List<A> list = new ArrayList<>(this.length);
+        ImmutableList<A> l = this;
+        for (int i = 0; i < length; i++) {
+            list.add(((NonEmptyImmutableList<A>) l).head);
+            l = ((NonEmptyImmutableList<A>) l).tail;
+        }
+        return list;
     }
 
     /**

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
@@ -463,8 +463,8 @@ public abstract class ImmutableList<A> implements Iterable<A> {
      * @return The list that contains the elements.
      */
     @Nonnull
-    public final List<A> toList() {
-        List<A> list = new ArrayList<>(this.length);
+    public final ArrayList<A> toArrayList() {
+        ArrayList<A> list = new ArrayList<>(this.length);
         ImmutableList<A> l = this;
         for (int i = 0; i < length; i++) {
             list.add(((NonEmptyImmutableList<A>) l).head);

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
@@ -379,6 +379,7 @@ public class ImmutableListTest extends TestBase {
     @Test
     public void testMutableRoundTrip() {
         ImmutableList<Integer> list = ImmutableList.of(1, 2, 3, 4, 5);
-        assertEquals(list, ImmutableList.from(list.toList()));
+        assertEquals(list, ImmutableList.from(list.toArrayList()));
+        assertEquals(list, ImmutableList.from(list.toLinkedList()));
     }
 }

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
@@ -17,6 +17,8 @@
 package com.shapesecurity.functional.data;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.shapesecurity.functional.Effect;
 import com.shapesecurity.functional.Pair;
@@ -372,5 +374,11 @@ public class ImmutableListTest extends TestBase {
         assertTrue(ImmutableList.of(0, 1).findIndex(i -> i == 1).fromJust() == 1);
         assertTrue(ImmutableList.of(0, 1, 1).findIndex(i -> i == 1).fromJust() == 1);
         assertTrue(ImmutableList.of(0, 1).findIndex(i -> i == 2).isNothing());
+    }
+
+    @Test
+    public void testMutableRoundTrip() {
+        ImmutableList<Integer> list = ImmutableList.of(1, 2, 3, 4, 5);
+        assertEquals(list, ImmutableList.from(list.toList()));
     }
 }


### PR DESCRIPTION
We may want to be more specific about the return type of `toList`, and perhaps rename it `toArrayList`, as a `toLinkedList` function may also be nice in some cases. Addresses #72.