### PR TITLE
ImmutableList::collector Implementation

### DIFF
--- a/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
@@ -26,16 +26,23 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
 
 /**
  * An immutable singly linked list implementation. None of the operations in {@link ImmutableList}
@@ -793,6 +800,39 @@ public abstract class ImmutableList<A> implements Iterable<A> {
             right = right.cons(result[i]);
         }
         return Pair.of(fromBounded(result, 0, l[0]), right);
+    }
+
+    @Nonnull
+    public static <T> Collector<T, ?, ImmutableList<T>> collector() {
+        return new Collector<T, ArrayList<T>, ImmutableList<T>>() {
+            @Override
+            public Supplier<ArrayList<T>> supplier() {
+                return ArrayList::new;
+            }
+
+            @Override
+            public BiConsumer<ArrayList<T>, T> accumulator() {
+                return ArrayList::add;
+            }
+
+            @Override
+            public BinaryOperator<ArrayList<T>> combiner() {
+                return (left, right) -> {
+                    left.addAll(right);
+                    return left;
+                };
+            }
+
+            @Override
+            public Function<ArrayList<T>, ImmutableList<T>> finisher() {
+                return ImmutableList::from;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return new HashSet<>();
+            }
+        };
     }
 }
 

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
@@ -19,7 +19,7 @@ package com.shapesecurity.functional.data;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
+import java.util.stream.StreamSupport;
 import com.shapesecurity.functional.Effect;
 import com.shapesecurity.functional.Pair;
 import com.shapesecurity.functional.TestBase;
@@ -402,5 +402,13 @@ public class ImmutableListTest extends TestBase {
 
         assertEquals(list.reverse(), ImmutableList.from(mutableList));
         assertEquals(mutableList, list.stream().sorted((int1, int2) -> int2 - int1).collect(Collectors.toList()));
+    }
+
+
+
+    @Test
+    public void testCollector() {
+        ImmutableList<Integer> list = ImmutableList.of(1, 2, 3, 4, 5);
+        assertEquals(list, StreamSupport.stream(list.spliterator(), false).map(x -> x + 1).map(x -> x - 1).collect(ImmutableList.collector()));
     }
 }


### PR DESCRIPTION
We may want to export the `Collector` as a static export, as it carries no internal state.