### PR TITLE
ImmutableSet::putAll, of for instantiation

### DIFF
--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -68,6 +68,23 @@ public class ImmutableSet<T> implements Iterable<T> {
     public static <T> ImmutableSet<T> fromUsingIdentity(@Nonnull Iterable<T> set) {
         return ImmutableSet.<T>emptyUsingIdentity().union(set);
     }
+        @Nonnull
+    @SafeVarargs
+    public static <T> ImmutableSet<T> ofUsingIdentity(@Nonnull T... items) {
+        return ImmutableSet.<T>emptyUsingIdentity().putAll(items);
+    }
+
+    @Nonnull
+    @SafeVarargs
+    public static <T> ImmutableSet<T> ofUsingEquality(@Nonnull T... items) {
+        return ImmutableSet.<T>emptyUsingEquality().putAll(items);
+    }
+
+    @Nonnull
+    @SafeVarargs
+    public static <T> ImmutableSet<T> of(@Nonnull T... items) {
+        return ofUsingEquality(items);
+    }
 
     @Deprecated
     @Nonnull
@@ -89,6 +106,15 @@ public class ImmutableSet<T> implements Iterable<T> {
     @Nonnull
     public <B extends T> ImmutableSet<T> putAll(@Nonnull ImmutableList<B> list) {
         return list.foldLeft(ImmutableSet::put, this);
+    }
+
+    @Nonnull
+    public <B extends T> ImmutableSet<T> putAll(@Nonnull B... list) {
+        ImmutableSet<T> set = this;
+        for (B b : list) {
+            set = set.put(b);
+        }
+        return set;
     }
 
     public boolean contains(@Nonnull T datum) {

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -56,17 +56,17 @@ public class ImmutableSet<T> implements Iterable<T> {
 
     @Nonnull
     public static <T> ImmutableSet<T> from(@Nonnull Hasher<T> hasher, @Nonnull Iterable<T> set) {
-        return empty(hasher).union(set);
+        return empty(hasher).putAll(set);
     }
 
     @Nonnull
     public static <T> ImmutableSet<T> fromUsingEquality(@Nonnull Iterable<T> set) {
-        return ImmutableSet.<T>emptyUsingEquality().union(set);
+        return ImmutableSet.<T>emptyUsingEquality().putAll(set);
     }
 
     @Nonnull
     public static <T> ImmutableSet<T> fromUsingIdentity(@Nonnull Iterable<T> set) {
-        return ImmutableSet.<T>emptyUsingIdentity().union(set);
+        return ImmutableSet.<T>emptyUsingIdentity().putAll(set);
     }
         @Nonnull
     @SafeVarargs
@@ -104,8 +104,12 @@ public class ImmutableSet<T> implements Iterable<T> {
     }
 
     @Nonnull
-    public <B extends T> ImmutableSet<T> putAll(@Nonnull ImmutableList<B> list) {
-        return list.foldLeft(ImmutableSet::put, this);
+    public <B extends T> ImmutableSet<T> putAll(@Nonnull Iterable<B> list) {
+        ImmutableSet<T> set = this;
+        for (B item : list) {
+            set = set.put(item);
+        }
+        return set;
     }
 
     @SafeVarargs
@@ -158,15 +162,6 @@ public class ImmutableSet<T> implements Iterable<T> {
     @Nonnull
     public ImmutableSet<T> union(@Nonnull ImmutableSet<T> other) {
         return new ImmutableSet<>(this.data.merge(other.data));
-    }
-
-    @Nonnull
-    public ImmutableSet<T> union(@Nonnull Iterable<T> other) {
-        ImmutableSet<T> set = this;
-        for (T entry : other) {
-            set = set.put(entry);
-        }
-        return set;
     }
 
     // Does not guarantee ordering of elements in resulting list.

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -71,13 +71,13 @@ public class ImmutableSet<T> implements Iterable<T> {
         @Nonnull
     @SafeVarargs
     public static <T> ImmutableSet<T> ofUsingIdentity(@Nonnull T... items) {
-        return ImmutableSet.<T>emptyUsingIdentity().putAll(items);
+        return ImmutableSet.<T>emptyUsingIdentity().putArray(items);
     }
 
     @Nonnull
     @SafeVarargs
     public static <T> ImmutableSet<T> ofUsingEquality(@Nonnull T... items) {
-        return ImmutableSet.<T>emptyUsingEquality().putAll(items);
+        return ImmutableSet.<T>emptyUsingEquality().putArray(items);
     }
 
     @Nonnull
@@ -108,8 +108,9 @@ public class ImmutableSet<T> implements Iterable<T> {
         return list.foldLeft(ImmutableSet::put, this);
     }
 
+    @SafeVarargs
     @Nonnull
-    public <B extends T> ImmutableSet<T> putAll(@Nonnull B... list) {
+    public final <B extends T> ImmutableSet<T> putArray(@Nonnull B... list) {
         ImmutableSet<T> set = this;
         for (B b : list) {
             set = set.put(b);

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
@@ -26,14 +26,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import java.util.stream.Stream;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
 import static org.junit.Assert.*;
 
 public class ImmutableSetTest extends TestBase {
@@ -238,8 +230,8 @@ public class ImmutableSetTest extends TestBase {
     @Test
     public void testPutAll() {
         ImmutableSet<String> set = ImmutableSet.of("key1", "key2", "key3");
-        assertEquals(set, set.putAll());
-        ImmutableSet<String> set2 = set.putAll("key4", "key5");
+        assertEquals(set, set.putArray());
+        ImmutableSet<String> set2 = set.putArray("key4", "key5");
         assertTrue(set2.contains("key4"));
         assertTrue(set2.contains("key2"));
         assertEquals(set2, ImmutableList.of("key1", "key2", "key3", "key4", "key5").uniqByEquality());

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
@@ -123,11 +123,11 @@ public class ImmutableSetTest extends TestBase {
         set.add("key3");
         ImmutableSet<String> table = ImmutableSet.fromUsingEquality(set);
         assertEquals(expected, table);
-        ImmutableSet<String> doubledSet = table.union(set);
+        ImmutableSet<String> doubledSet = table.putAll(set);
         assertEquals(table, doubledSet);
         set.add("key4");
         expected = expected.put("key4");
-        assertEquals(expected, table.union(set));
+        assertEquals(expected, table.putAll(set));
     }
 
 

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
@@ -26,6 +26,14 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import java.util.stream.Stream;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
 import static org.junit.Assert.*;
 
 public class ImmutableSetTest extends TestBase {
@@ -225,5 +233,15 @@ public class ImmutableSetTest extends TestBase {
         ImmutableSet<String> streamed = Stream.of("1", "2", "3", "4", "5", "5").collect(ImmutableSet.collector());
         assertEquals(set, streamed);
         assertEquals(5, set.length());
+    }
+
+    @Test
+    public void testPutAll() {
+        ImmutableSet<String> set = ImmutableSet.of("key1", "key2", "key3");
+        assertEquals(set, set.putAll());
+        ImmutableSet<String> set2 = set.putAll("key4", "key5");
+        assertTrue(set2.contains("key4"));
+        assertTrue(set2.contains("key2"));
+        assertEquals(set2, ImmutableList.of("key1", "key2", "key3", "key4", "key5").uniqByEquality());
     }
 }


### PR DESCRIPTION
Prevents verbose manual creation of sets with default entries.