### PR TITLE
Nonnullify ImmutableSet

### DIFF
--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -22,28 +22,34 @@ public class ImmutableSet<T> implements Iterable<T> {
         this.data = data;
     }
 
+    @Nonnull
     public static <T> ImmutableSet<T> empty(@Nonnull Hasher<T> hasher) {
         return new ImmutableSet<>(HashTable.empty(hasher));
     }
 
+    @Nonnull
     public static <T> ImmutableSet<T> emptyUsingEquality() {
         return new ImmutableSet<>(HashTable.emptyUsingEquality());
     }
 
+    @Nonnull
     public static <T> ImmutableSet<T> emptyUsingIdentity() {
         return new ImmutableSet<>(HashTable.emptyUsingIdentity());
     }
 
     @Deprecated
+    @Nonnull
     public static <T> ImmutableSet<T> empty() {
         return ImmutableSet.emptyUsingEquality();
     }
 
     @Deprecated
+    @Nonnull
     public static <T> ImmutableSet<T> emptyP() {
         return ImmutableSet.emptyUsingIdentity();
     }
 
+    @Nonnull
     public <B extends T> ImmutableSet<T> put(@Nonnull B datum) {
         return new ImmutableSet<>(this.data.put(datum, Unit.unit));
     }
@@ -57,24 +63,29 @@ public class ImmutableSet<T> implements Iterable<T> {
         return this.data.containsKey(datum);
     }
 
+    @Nonnull
     @SuppressWarnings("unchecked")
     public <A> ImmutableSet<A> map(@Nonnull F<T, A> f) {
         return this.foldAbelian((val, acc) -> acc.put(f.apply(val)), ImmutableSet.empty((Hasher<A>) this.data.hasher));
     }
 
+    @Nonnull
     public ImmutableSet<T> remove(@Nonnull T datum) {
         return new ImmutableSet<>(this.data.remove(datum));
     }
 
+    @Nonnull
     public <A> A foldAbelian(@Nonnull F2<T, A, A> f, @Nonnull A init) {
         return this.data.foldRight((p, acc) -> f.apply(p.left, acc), init);
     }
 
+    @Nonnull
     public ImmutableSet<T> union(@Nonnull ImmutableSet<T> other) {
         return new ImmutableSet<>(this.data.merge(other.data));
     }
 
     // Does not guarantee ordering of elements in resulting list.
+    @Nonnull
     public ImmutableList<T> toList() {
         return this.foldAbelian((v, acc) -> acc.cons(v), ImmutableList.empty());
     }
@@ -86,6 +97,7 @@ public class ImmutableSet<T> implements Iterable<T> {
     }
 
     @Override
+    @Nonnull
     public Iterator<T> iterator() {
         final Iterator<Pair<T, Unit>> mapIterator = this.data.iterator();
         return new Iterator<T>() {


### PR DESCRIPTION
This is a breaking change and probably should be thrown out *if* we consider warnings disappearing/appearing from this change to be breaking. Nothing should fail to compile.