### PR TITLE
ImmutableSet::union, from for mutable Set

### DIFF
--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -8,6 +8,7 @@ import com.shapesecurity.functional.Unit;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import java.util.Iterator;
+import java.util.Set;
 
 @CheckReturnValue
 public class ImmutableSet<T> implements Iterable<T> {
@@ -32,6 +33,21 @@ public class ImmutableSet<T> implements Iterable<T> {
 
     public static <T> ImmutableSet<T> emptyUsingIdentity() {
         return new ImmutableSet<>(HashTable.emptyUsingIdentity());
+    }
+
+    @Nonnull
+    public static <T> ImmutableSet<T> from(@Nonnull Hasher<T> hasher, @Nonnull Set<T> set) {
+        return empty(hasher).union(set);
+    }
+
+    @Nonnull
+    public static <T> ImmutableSet<T> fromUsingEquality(@Nonnull Set<T> set) {
+        return ImmutableSet.<T>emptyUsingEquality().union(set);
+    }
+
+    @Nonnull
+    public static <T> ImmutableSet<T> fromUsingIdentity(@Nonnull Set<T> set) {
+        return ImmutableSet.<T>emptyUsingIdentity().union(set);
     }
 
     @Deprecated
@@ -72,6 +88,15 @@ public class ImmutableSet<T> implements Iterable<T> {
 
     public ImmutableSet<T> union(@Nonnull ImmutableSet<T> other) {
         return new ImmutableSet<>(this.data.merge(other.data));
+    }
+
+    @Nonnull
+    public ImmutableSet<T> union(@Nonnull Set<T> other) {
+        ImmutableSet<T> set = this;
+        for (T entry : other) {
+            set = set.put(entry);
+        }
+        return set;
     }
 
     // Does not guarantee ordering of elements in resulting list.

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -8,7 +8,6 @@ import com.shapesecurity.functional.Unit;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import java.util.Iterator;
-import java.util.Set;
 
 @CheckReturnValue
 public class ImmutableSet<T> implements Iterable<T> {
@@ -36,17 +35,17 @@ public class ImmutableSet<T> implements Iterable<T> {
     }
 
     @Nonnull
-    public static <T> ImmutableSet<T> from(@Nonnull Hasher<T> hasher, @Nonnull Set<T> set) {
+    public static <T> ImmutableSet<T> from(@Nonnull Hasher<T> hasher, @Nonnull Iterable<T> set) {
         return empty(hasher).union(set);
     }
 
     @Nonnull
-    public static <T> ImmutableSet<T> fromUsingEquality(@Nonnull Set<T> set) {
+    public static <T> ImmutableSet<T> fromUsingEquality(@Nonnull Iterable<T> set) {
         return ImmutableSet.<T>emptyUsingEquality().union(set);
     }
 
     @Nonnull
-    public static <T> ImmutableSet<T> fromUsingIdentity(@Nonnull Set<T> set) {
+    public static <T> ImmutableSet<T> fromUsingIdentity(@Nonnull Iterable<T> set) {
         return ImmutableSet.<T>emptyUsingIdentity().union(set);
     }
 
@@ -91,7 +90,7 @@ public class ImmutableSet<T> implements Iterable<T> {
     }
 
     @Nonnull
-    public ImmutableSet<T> union(@Nonnull Set<T> other) {
+    public ImmutableSet<T> union(@Nonnull Iterable<T> other) {
         ImmutableSet<T> set = this;
         for (T entry : other) {
             set = set.put(entry);

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
@@ -18,10 +18,15 @@ package com.shapesecurity.functional.data;
 
 import com.shapesecurity.functional.Pair;
 import com.shapesecurity.functional.TestBase;
-import com.shapesecurity.functional.Unit;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -106,5 +111,24 @@ public class ImmutableSetTest extends TestBase {
         assertFalse(m.contains(1));
         assertTrue(m.contains(2));
         assertFalse(m.contains(3));
+    }
+
+    @Test
+    public void mutableUnionTest() {
+        ImmutableSet<String> expected = ImmutableSet.<String>emptyUsingEquality()
+            .put("key1")
+            .put("key2")
+            .put("key3");
+        Set<String> set = new HashSet<>();
+        set.add("key1");
+        set.add("key2");
+        set.add("key3");
+        ImmutableSet<String> table = ImmutableSet.fromUsingEquality(set);
+        assertEquals(expected, table);
+        ImmutableSet<String> doubledSet = table.union(set);
+        assertEquals(table, doubledSet);
+        set.add("key4");
+        expected = expected.put("key4");
+        assertEquals(expected, table.union(set));
     }
 }


### PR DESCRIPTION
Allows easier transfer from mutable to immutable types. Addresses #71.