### PR TITLE
ImmutableSet::flatMap Implementation

### DIFF
--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -85,6 +85,11 @@ public class ImmutableSet<T> implements Iterable<T> {
     }
 
     @Nonnull
+    @SuppressWarnings("unchecked")
+    public <A> ImmutableSet<A> flatMap(@Nonnull F<T, ImmutableSet<A>> f) {
+        return this.foldAbelian((t, acc) -> acc.union(f.apply(t)), ImmutableSet.empty((Hasher<A>) this.data.hasher));
+    }
+
     public ImmutableSet<T> remove(@Nonnull T datum) {
         return new ImmutableSet<>(this.data.remove(datum));
     }

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -87,7 +87,13 @@ public class ImmutableSet<T> implements Iterable<T> {
     @Nonnull
     @SuppressWarnings("unchecked")
     public <A> ImmutableSet<A> flatMap(@Nonnull F<T, ImmutableSet<A>> f) {
-        return this.foldAbelian((t, acc) -> acc.union(f.apply(t)), ImmutableSet.empty((Hasher<A>) this.data.hasher));
+        return this.foldAbelian((t, acc) -> {
+            ImmutableSet<A> set = f.apply(t);
+            if (!set.data.hasher.equals(acc.data.hasher)) {
+                throw new UnsupportedOperationException("Hasher mismatch in flatMap.");
+            }
+            return acc.union(set);
+        }, ImmutableSet.empty((Hasher<A>) this.data.hasher));
     }
 
     public ImmutableSet<T> remove(@Nonnull T datum) {

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
@@ -16,17 +16,11 @@
 
 package com.shapesecurity.functional.data;
 
-import com.shapesecurity.functional.Pair;
 import com.shapesecurity.functional.TestBase;
 import org.junit.Test;
 
-import javax.annotation.Nonnull;
-
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -130,5 +124,24 @@ public class ImmutableSetTest extends TestBase {
         set.add("key4");
         expected = expected.put("key4");
         assertEquals(expected, table.union(set));
+    }
+
+
+    @Test
+    public void flatMapTest() {
+        ImmutableSet<String> expected = ImmutableSet.<String>emptyUsingEquality()
+            .put("key1")
+            .put("key2")
+            .put("key3");
+        ImmutableSet<String> mappedSet = expected.flatMap(string -> ImmutableSet.<String>emptyUsingEquality().put(string + "1").put(string + "2"));
+        assertEquals(ImmutableSet.<String>emptyUsingEquality()
+                .put("key11")
+                .put("key21")
+                .put("key31")
+                .put("key12")
+                .put("key22")
+                .put("key32"),
+            mappedSet
+        );
     }
 }


### PR DESCRIPTION
Mirrors `ImmutableSet::map`. Addresses #68.