### PR TITLE
ImmutableSet::collector Implementation

### DIFF
--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -202,7 +202,7 @@ public class ImmutableSet<T> implements Iterable<T> {
 
     @Nonnull
     public static <T> Collector<T, ?, ImmutableSet<T>> collector(@Nonnull Hasher<T> hasher) {
-        // we use a list for state because java doesnt support our Hasher type
+        // we use a list for state because java doesn't support our Hasher type
         return new Collector<T, ArrayList<T>, ImmutableSet<T>>() {
             @Override
             public Supplier<ArrayList<T>> supplier() {

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.*;
 
@@ -216,5 +217,13 @@ public class ImmutableSetTest extends TestBase {
         List<Integer> mutableListFromList = StreamSupport.stream(set.toList().spliterator(), false)
             .sorted(Integer::compareTo).collect(Collectors.toList());
         assertEquals(mutableList, mutableListFromList);
+    }
+
+    @Test
+    public void testCollector() {
+        ImmutableSet<String> set = ImmutableList.of("1", "2", "3", "4", "5", "5").uniqByEquality();
+        ImmutableSet<String> streamed = Stream.of("1", "2", "3", "4", "5", "5").collect(ImmutableSet.collector());
+        assertEquals(set, streamed);
+        assertEquals(5, set.length());
     }
 }


### PR DESCRIPTION
We may want the `collector` methods to be static variables as they do not have any internal state.