### PR TITLE
Optimize ImmutableList::from for LinkedList

### DIFF
--- a/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
@@ -125,8 +125,7 @@ public abstract class ImmutableList<A> implements Iterable<A> {
     @Nonnull
     public static <A> ImmutableList<A> from(@Nonnull Iterable<A> list) {
         ImmutableList<A> l = empty();
-        for (Iterator<A> iterator = list.iterator(); iterator.hasNext();) {
-            A item = iterator.next();
+        for (A item : list) {
             l = cons(item, l);
         }
         return l.reverse();

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
@@ -124,11 +124,14 @@ public abstract class ImmutableList<A> implements Iterable<A> {
      */
     @Nonnull
     public static <A> ImmutableList<A> from(@Nonnull Iterable<A> list) {
-        ImmutableList<A> l = empty();
-        for (A item : list) {
-            l = cons(item, l);
-        }
-        return l.reverse();
+		if (list instanceof ArrayList) {
+			return from((ArrayList<A>) list);
+		} else if (list instanceof LinkedList) {
+			return from((LinkedList<A>) list);
+		}
+		ArrayList<A> arrayList = new ArrayList<>();
+		list.forEach(arrayList::add);
+		return from(arrayList);
     }
 
     @Nonnull

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -75,31 +76,60 @@ public abstract class ImmutableList<A> implements Iterable<A> {
     }
 
     /**
-     * Creating List from.
+     * Creating ImmutableList from an ArrayList.
      *
-     * @param arrayList The {@link java.util.ArrayList} to construct the {@link ImmutableList}
+     * @param list      The {@link java.util.ArrayList} to construct the {@link ImmutableList}
      *                  from.
      * @param <A>       The type of the elements of the list.
      * @return a new {@link ImmutableList} that is comprised of all the elements in the {@link
      * java.util.ArrayList}.
      */
     @Nonnull
-    public static <A> ImmutableList<A> from(@Nonnull List<A> arrayList) {
-        // Manual expansion of tail recursion.
+    public static <A> ImmutableList<A> from(@Nonnull ArrayList<A> list) {
         ImmutableList<A> l = empty();
-        int size = arrayList.size();
+        int size = list.size();
         for (int i = size - 1; i >= 0; i--) {
-            l = cons(arrayList.get(i), l);
+            l = cons(list.get(i), l);
         }
         return l;
-    /* TODO: use Collection here if it doesn't incur performance penalties
-    ImmutableList<A> list = empty();
-    int size = collection.size();
-    for (A element : collection) {
-      list = cons(element, list);
     }
-    return list;
+
+    /**
+     * Creating ImmutableList from a Deque. Generally used for {@link java.util.LinkedList}, but applicable to reverse iterable types in general.
+     *
+     * @param list      The {@link java.util.Deque} to construct the {@link ImmutableList}
+     *                  from.
+     * @param <A>       The type of the elements of the list.
+     * @return a new {@link ImmutableList} that is comprised of all the elements in the {@link
+     * java.util.Deque}.
      */
+    @Nonnull
+    public static <A> ImmutableList<A> from(@Nonnull Deque<A> list) {
+        ImmutableList<A> l = empty();
+        for (Iterator<A> iterator = list.descendingIterator(); iterator.hasNext();) {
+            A item = iterator.next();
+            l = cons(item, l);
+        }
+        return l;
+    }
+
+    /**
+     * Creating ImmutableList from an Iterable.
+     *
+     * @param list      The {@link java.lang.Iterable} to construct the {@link ImmutableList}
+     *                  from.
+     * @param <A>       The type of the elements of the list.
+     * @return a new {@link ImmutableList} that is comprised of all the elements in the {@link
+     * java.util.ArrayList}.
+     */
+    @Nonnull
+    public static <A> ImmutableList<A> from(@Nonnull Iterable<A> list) {
+        ImmutableList<A> l = empty();
+        for (Iterator<A> iterator = list.iterator(); iterator.hasNext();) {
+            A item = iterator.next();
+            l = cons(item, l);
+        }
+        return l.reverse();
     }
 
     @Nonnull

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
@@ -125,7 +125,8 @@ public class ImmutableListTest extends TestBase {
     }
 
     private void testFromIterable(ImmutableList<Integer> list) {
-        ImmutableList<Integer> listP = ImmutableList.from(list); // ImmutableList itself is Iterable
+        // ImmutableList itself is Iterable, cast is redundant for clarity
+        ImmutableList<Integer> listP = ImmutableList.from((Iterable<Integer>) list);
         assertEquals(list, listP);
     }
 

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import java.util.LinkedList;
+
 import com.shapesecurity.functional.Effect;
 import com.shapesecurity.functional.Pair;
 import com.shapesecurity.functional.TestBase;
@@ -95,8 +97,10 @@ public class ImmutableListTest extends TestBase {
 
     @Test
     public void testFrom() {
-        testWithSpecialLists(this::testFrom);
         testWithSpecialLists(this::testFromArray);
+        testWithSpecialLists(this::testFromArrayList);
+        testWithSpecialLists(this::testFromLinkedList);
+        testWithSpecialLists(this::testFromIterable);
     }
 
     private void testFromArray(ImmutableList<Integer> list) {
@@ -106,10 +110,22 @@ public class ImmutableListTest extends TestBase {
         assertEquals(list, list1);
     }
 
-    private void testFrom(ImmutableList<Integer> list) {
+    private void testFromArrayList(ImmutableList<Integer> list) {
         final ArrayList<Integer> arrList = new ArrayList<>();
         list.forEach(arrList::add);
         ImmutableList<Integer> listP = ImmutableList.from(arrList);
+        assertEquals(list, listP);
+    }
+
+    private void testFromLinkedList(ImmutableList<Integer> list) {
+        final LinkedList<Integer> arrList = new LinkedList<>();
+        list.forEach(arrList::add);
+        ImmutableList<Integer> listP = ImmutableList.from(arrList);
+        assertEquals(list, listP);
+    }
+
+    private void testFromIterable(ImmutableList<Integer> list) {
+        ImmutableList<Integer> listP = ImmutableList.from(list); // ImmutableList itself is Iterable
         assertEquals(list, listP);
     }
 
@@ -392,7 +408,6 @@ public class ImmutableListTest extends TestBase {
         assertEquals(list, ImmutableList.from(list.toLinkedList()));
     }
 
-
     @Test
     public void testStream() {
         ImmutableList<Integer> list = ImmutableList.of(1, 2, 3, 4, 5);
@@ -403,8 +418,6 @@ public class ImmutableListTest extends TestBase {
         assertEquals(list.reverse(), ImmutableList.from(mutableList));
         assertEquals(mutableList, list.stream().sorted((int1, int2) -> int2 - int1).collect(Collectors.toList()));
     }
-
-
 
     @Test
     public void testCollector() {


### PR DESCRIPTION
Despite removing a method, this is not a breaking change, as previous calls to `from` will be consumed by either `from(java.lang.Iterable)`, `from(java.util.ArrayList)`, or `from(java.util.LinkedList)`.

Reduces the complexity of calling `from` on a `LinkedList` from O(n^2) to O(n).