### PR TITLE
Fix ABI, version 2.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity</groupId>
     <artifactId>shape-functional-java</artifactId>
-    <version>2.6.1</version>
+    <version>2.6.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Shape Functional Java</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity</groupId>
     <artifactId>shape-functional-java</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.1</version>
     <packaging>jar</packaging>
 
     <name>Shape Functional Java</name>

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableList.java
@@ -95,43 +95,44 @@ public abstract class ImmutableList<A> implements Iterable<A> {
     }
 
     /**
-     * Creating ImmutableList from a Deque. Generally used for {@link java.util.LinkedList}, but applicable to reverse iterable types in general.
-     *
-     * @param list      The {@link java.util.Deque} to construct the {@link ImmutableList}
-     *                  from.
-     * @param <A>       The type of the elements of the list.
-     * @return a new {@link ImmutableList} that is comprised of all the elements in the {@link
-     * java.util.Deque}.
-     */
-    @Nonnull
-    public static <A> ImmutableList<A> from(@Nonnull Deque<A> list) {
-        ImmutableList<A> l = empty();
-        for (Iterator<A> iterator = list.descendingIterator(); iterator.hasNext();) {
-            A item = iterator.next();
-            l = cons(item, l);
-        }
-        return l;
-    }
-
-    /**
      * Creating ImmutableList from an Iterable.
      *
      * @param list      The {@link java.lang.Iterable} to construct the {@link ImmutableList}
      *                  from.
      * @param <A>       The type of the elements of the list.
      * @return a new {@link ImmutableList} that is comprised of all the elements in the {@link
-     * java.util.ArrayList}.
+     * java.lang.Iterable}.
      */
     @Nonnull
     public static <A> ImmutableList<A> from(@Nonnull Iterable<A> list) {
-		if (list instanceof ArrayList) {
-			return from((ArrayList<A>) list);
-		} else if (list instanceof LinkedList) {
-			return from((LinkedList<A>) list);
-		}
-		ArrayList<A> arrayList = new ArrayList<>();
-		list.forEach(arrayList::add);
-		return from(arrayList);
+        if (list instanceof ArrayList) {
+            return from((ArrayList<A>) list);
+        } else if (list instanceof Deque) {
+            // Deque is inlined here to prevent ambiguous method call errors when passing `LinkedList` types to `from`.
+            ImmutableList<A> l = empty();
+            for (Iterator<A> iterator = ((Deque<A>) list).descendingIterator(); iterator.hasNext();) {
+                A item = iterator.next();
+                l = cons(item, l);
+            }
+            return l;
+        }
+        ArrayList<A> arrayList = new ArrayList<>();
+        list.forEach(arrayList::add);
+        return from(arrayList);
+    }
+
+    /**
+     * Creating ImmutableList from a list. While redundant, this method provides ABI compatibility with prior releases.
+     *
+     * @param list      The {@link java.util.List} to construct the {@link ImmutableList}
+     *                  from.
+     * @param <A>       The type of the elements of the list.
+     * @return a new {@link ImmutableList} that is comprised of all the elements in the {@link
+     * java.util.ArrayList}.
+     */
+    @Nonnull
+    public static <A> ImmutableList<A> from(@Nonnull List<A> list) {
+        return from((Iterable<A>) list);
     }
 
     @Nonnull
@@ -691,7 +692,7 @@ public abstract class ImmutableList<A> implements Iterable<A> {
      * <code>Maybe.empty()</code> if none is found.
      */
     @Nonnull
-	public final Maybe<Integer> findIndex(@Nonnull F<A, Boolean> f) {
+    public final Maybe<Integer> findIndex(@Nonnull F<A, Boolean> f) {
         ImmutableList<A> self = this;
         int i = 0;
         while (self instanceof NonEmptyImmutableList) {
@@ -703,7 +704,7 @@ public abstract class ImmutableList<A> implements Iterable<A> {
             ++i;
         }
         return Maybe.empty();
-	}
+    }
 
     /**
      * Run <code>f</code> on each element of the list and return the result immediately if it is a

--- a/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
+++ b/src/main/java/com/shapesecurity/functional/data/ImmutableSet.java
@@ -112,6 +112,12 @@ public class ImmutableSet<T> implements Iterable<T> {
         return set;
     }
 
+    // to prevent ABI breaking, this function must exist
+    @Nonnull
+    public <B extends T> ImmutableSet<T> putAll(@Nonnull ImmutableList<B> list) {
+        return this.putAll((Iterable<B>) list);
+    }
+
     @SafeVarargs
     @Nonnull
     public final <B extends T> ImmutableSet<T> putArray(@Nonnull B... list) {

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableListTest.java
@@ -99,6 +99,7 @@ public class ImmutableListTest extends TestBase {
     public void testFrom() {
         testWithSpecialLists(this::testFromArray);
         testWithSpecialLists(this::testFromArrayList);
+        testWithSpecialLists(this::testFromList);
         testWithSpecialLists(this::testFromLinkedList);
         testWithSpecialLists(this::testFromIterable);
     }
@@ -112,6 +113,13 @@ public class ImmutableListTest extends TestBase {
 
     private void testFromArrayList(ImmutableList<Integer> list) {
         final ArrayList<Integer> arrList = new ArrayList<>();
+        list.forEach(arrList::add);
+        ImmutableList<Integer> listP = ImmutableList.from(arrList);
+        assertEquals(list, listP);
+    }
+
+    private void testFromList(ImmutableList<Integer> list) {
+        final List<Integer> arrList = new ArrayList<>();
         list.forEach(arrList::add);
         ImmutableList<Integer> listP = ImmutableList.from(arrList);
         assertEquals(list, listP);

--- a/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/ImmutableSetTest.java
@@ -19,6 +19,7 @@ package com.shapesecurity.functional.data;
 import com.shapesecurity.functional.TestBase;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.List;
@@ -232,8 +233,13 @@ public class ImmutableSetTest extends TestBase {
         ImmutableSet<String> set = ImmutableSet.of("key1", "key2", "key3");
         assertEquals(set, set.putArray());
         ImmutableSet<String> set2 = set.putArray("key4", "key5");
-        assertTrue(set2.contains("key4"));
         assertTrue(set2.contains("key2"));
+        assertTrue(set2.contains("key4"));
+        assertTrue(set2.contains("key5"));
+        ImmutableSet<String> set3 = set.putAll(ImmutableList.of("key5", "key4"));
+        ImmutableSet<String> set4 = set.putAll(Arrays.asList("key5", "key4"));
+        assertEquals(set2, set3);
+        assertEquals(set2, set4);
         assertEquals(set2, ImmutableList.of("key1", "key2", "key3", "key4", "key5").uniqByEquality());
     }
 }


### PR DESCRIPTION
While technically a breaking ABI change in and of itself, this PR prevents a breaking ABI change from removing `ImmutableList::from(Ljava.util.List;)` in favor of `Iterable`. `from(Deque)` also had to be merged into `from(Iterable)` to prevent ambiguous method calls for `LinkedList` types, and `from(ArrayList)` followed suit for consistency.