### PR TITLE
add helper for unwrapping eithers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity</groupId>
     <artifactId>shape-functional-java</artifactId>
-    <version>2.7.1-SNAPSHOT</version>
+    <version>2.8.0</version>
     <packaging>jar</packaging>
 
     <name>Shape Functional Java</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity</groupId>
     <artifactId>shape-functional-java</artifactId>
-    <version>2.8.0</version>
+    <version>2.8.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Shape Functional Java</name>

--- a/src/main/java/com/shapesecurity/functional/data/Either.java
+++ b/src/main/java/com/shapesecurity/functional/data/Either.java
@@ -117,6 +117,24 @@ public final class Either<A, B> {
         return this.tag == Tag.RIGHT ? Maybe.of((B) this.data) : Maybe.empty();
     }
 
+    @SuppressWarnings("unchecked")
+    @Nonnull
+    public A fromLeft() {
+        if (this.tag != Tag.LEFT) {
+            throw new RuntimeException("Either fromLeft called on right");
+        }
+        return (A) this.data;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nonnull
+    public B fromRight() {
+        if (this.tag != Tag.RIGHT) {
+            throw new RuntimeException("Either fromRight called on left");
+        }
+        return (B) this.data;
+    }
+
     private boolean eq(@Nonnull Either<A, B> either) {
         return either.tag == this.tag && either.data.equals(this.data);
     }

--- a/src/test/java/com/shapesecurity/functional/data/EitherTest.java
+++ b/src/test/java/com/shapesecurity/functional/data/EitherTest.java
@@ -41,6 +41,7 @@ public class EitherTest {
         assertTrue(e1.right().isNothing());
         assertEquals("a", e1.left().fromJust());
         assertEquals("a", e1.left().fromJust());
+        assertEquals("a", e1.fromLeft());
         assertTrue(e1.mapRight(plusOne).left().isJust());
         assertTrue(e1.mapRight(plusOne).right().isNothing());
         assertEquals("a", e1.mapRight(plusOne).left().fromJust());
@@ -54,6 +55,7 @@ public class EitherTest {
         assertTrue(e2.right().isJust());
         assertEquals(1, (int) e2.right().fromJust());
         assertEquals(1, (int) e2.right().fromJust());
+        assertEquals(1, (int) e2.fromRight());
         assertTrue(e2.mapRight(plusOne).left().isNothing());
         assertTrue(e2.mapRight(plusOne).right().isJust());
         assertEquals(2, (int) e2.mapRight(plusOne).right().fromJust());
@@ -95,5 +97,15 @@ public class EitherTest {
         } catch (Exception e) {
             fail("Either._try should never allow exceptions to propagate");
         }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testFromLeft() {
+        Either.right("x").fromLeft();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testFromRight() {
+        Either.left("x").fromRight();
     }
 }


### PR DESCRIPTION
I end up with a lot of code which looks like

```java
if (either.isLeft()) {
  return either.left().fromJust();
}
```

The intermediate `Maybe` seems silly. This would let me write

```java
if (either.isLeft()) {
  return either.fromLeft();
}
```
which better matches the pattern for `Maybe`:

```java
if (maybe.isJust()) {
  return maybe.fromJust();
}
```


Includes version bump commit, so please **rebase**, not squash.